### PR TITLE
Ocaml protoc as lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
 
       - run: opam exec -- dune build @install -p opentelemetry,opentelemetry-lwt,opentelemetry-client-ocurl,opentelemetry-cohttp-lwt
 
+      - run: opam install ocaml-protoc -y
+
       - run: opam exec -- dune build @lint
 
       # check that nothing changed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
 
       - run: opam exec -- dune build @install -p opentelemetry,opentelemetry-lwt,opentelemetry-client-ocurl,opentelemetry-cohttp-lwt
 
-      - run: dune build @lint
+      - run: opam exec -- dune build @lint
 
       # check that nothing changed
       - run: git diff --quiet --exit-code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,5 +41,5 @@ jobs:
 
       - run: opam exec -- dune build @install -p opentelemetry,opentelemetry-lwt,opentelemetry-client-ocurl,opentelemetry-cohttp-lwt
 
-      - run: opam exec -- dune build @runtest
+      - run: opam exec -- dune build @runtest --ignore-promoted-rules
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,5 +41,10 @@ jobs:
 
       - run: opam exec -- dune build @install -p opentelemetry,opentelemetry-lwt,opentelemetry-client-ocurl,opentelemetry-cohttp-lwt
 
-      - run: opam exec -- dune build @runtest --ignore-promoted-rules
+      - run: dune build @lint
+
+      # check that nothing changed
+      - run: git diff --quiet --exit-code
+
+      - run: opam exec -- dune build @runtest
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ clean:
 protoc-gen:
 	@dune build @lint
 
+format:
+	@dune fmt
+
 WATCH ?= @all
 watch:
 	@dune build $(WATCH) -w $(OPTS)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ test:
 clean:
 	@dune clean
 
+protoc-gen:
+	@dune build @lint
+
 WATCH ?= @all
 watch:
 	@dune build $(WATCH) -w $(OPTS)

--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,7 @@
    (ocaml (>= "4.08"))
    ptime
    (odoc :with-doc)
-   (ocaml-protoc (>= 2.1)))
+   (pbrt (>= 2.2)))
  (tags
   (instrumentation tracing opentelemetry datadog jaeger)))
 
@@ -41,7 +41,7 @@
    (mtime (>= "1.4")) ; for spans
    ; atomic ; vendored
    (opentelemetry (= :version))
-   (ocaml-protoc (>= 2.1))
+   (pbrt (>= 2.2))
    (odoc :with-doc)
    ocurl)
   (synopsis "Collector client for opentelemetry, using http + ocurl"))

--- a/opentelemetry-client-ocurl.opam
+++ b/opentelemetry-client-ocurl.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "mtime" {>= "1.4"}
   "opentelemetry" {= version}
-  "ocaml-protoc" {>= "2.1"}
+  "pbrt" {>= "2.2"}
   "odoc" {with-doc}
   "ocurl"
 ]

--- a/opentelemetry.opam
+++ b/opentelemetry.opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "ptime"
   "odoc" {with-doc}
-  "ocaml-protoc" {>= "2.1"}
+  "pbrt" {>= "2.2"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/src/client/dune
+++ b/src/client/dune
@@ -3,6 +3,6 @@
   (name opentelemetry_client_ocurl)
   (public_name opentelemetry-client-ocurl)
   (libraries opentelemetry opentelemetry.atomic
-             curl ocaml-protoc threads
+             curl pbrt threads
              mtime mtime.clock.os))
 

--- a/src/common_pb.ml
+++ b/src/common_pb.ml
@@ -1,0 +1,201 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type array_value_mutable = {
+  mutable values : Common_types.any_value list;
+}
+
+let default_array_value_mutable () : array_value_mutable = {
+  values = [];
+}
+
+type key_value_list_mutable = {
+  mutable values : Common_types.key_value list;
+}
+
+let default_key_value_list_mutable () : key_value_list_mutable = {
+  values = [];
+}
+
+type key_value_mutable = {
+  mutable key : string;
+  mutable value : Common_types.any_value option;
+}
+
+let default_key_value_mutable () : key_value_mutable = {
+  key = "";
+  value = None;
+}
+
+type instrumentation_library_mutable = {
+  mutable name : string;
+  mutable version : string;
+}
+
+let default_instrumentation_library_mutable () : instrumentation_library_mutable = {
+  name = "";
+  version = "";
+}
+
+
+let rec decode_any_value d = 
+  let rec loop () = 
+    let ret:Common_types.any_value = match Pbrt.Decoder.key d with
+      | None -> Pbrt.Decoder.malformed_variant "any_value"
+      | Some (1, _) -> (Common_types.String_value (Pbrt.Decoder.string d) : Common_types.any_value) 
+      | Some (2, _) -> (Common_types.Bool_value (Pbrt.Decoder.bool d) : Common_types.any_value) 
+      | Some (3, _) -> (Common_types.Int_value (Pbrt.Decoder.int64_as_varint d) : Common_types.any_value) 
+      | Some (4, _) -> (Common_types.Double_value (Pbrt.Decoder.float_as_bits64 d) : Common_types.any_value) 
+      | Some (5, _) -> (Common_types.Array_value (decode_array_value (Pbrt.Decoder.nested d)) : Common_types.any_value) 
+      | Some (6, _) -> (Common_types.Kvlist_value (decode_key_value_list (Pbrt.Decoder.nested d)) : Common_types.any_value) 
+      | Some (7, _) -> (Common_types.Bytes_value (Pbrt.Decoder.bytes d) : Common_types.any_value) 
+      | Some (n, payload_kind) -> (
+        Pbrt.Decoder.skip d payload_kind; 
+        loop () 
+      )
+    in
+    ret
+  in
+  loop ()
+
+and decode_array_value d =
+  let v = default_array_value_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.values <- List.rev v.values;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.values <- (decode_any_value (Pbrt.Decoder.nested d)) :: v.values;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(array_value), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Common_types.values = v.values;
+  } : Common_types.array_value)
+
+and decode_key_value_list d =
+  let v = default_key_value_list_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.values <- List.rev v.values;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.values <- (decode_key_value (Pbrt.Decoder.nested d)) :: v.values;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(key_value_list), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Common_types.values = v.values;
+  } : Common_types.key_value_list)
+
+and decode_key_value d =
+  let v = default_key_value_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.key <- Pbrt.Decoder.string d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(key_value), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.value <- Some (decode_any_value (Pbrt.Decoder.nested d));
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(key_value), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Common_types.key = v.key;
+    Common_types.value = v.value;
+  } : Common_types.key_value)
+
+let rec decode_instrumentation_library d =
+  let v = default_instrumentation_library_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.name <- Pbrt.Decoder.string d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(instrumentation_library), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.version <- Pbrt.Decoder.string d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(instrumentation_library), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Common_types.name = v.name;
+    Common_types.version = v.version;
+  } : Common_types.instrumentation_library)
+
+let rec encode_any_value (v:Common_types.any_value) encoder = 
+  begin match v with
+  | Common_types.String_value x ->
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.string x encoder;
+  | Common_types.Bool_value x ->
+    Pbrt.Encoder.key (2, Pbrt.Varint) encoder; 
+    Pbrt.Encoder.bool x encoder;
+  | Common_types.Int_value x ->
+    Pbrt.Encoder.key (3, Pbrt.Varint) encoder; 
+    Pbrt.Encoder.int64_as_varint x encoder;
+  | Common_types.Double_value x ->
+    Pbrt.Encoder.key (4, Pbrt.Bits64) encoder; 
+    Pbrt.Encoder.float_as_bits64 x encoder;
+  | Common_types.Array_value x ->
+    Pbrt.Encoder.key (5, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_array_value x) encoder;
+  | Common_types.Kvlist_value x ->
+    Pbrt.Encoder.key (6, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_key_value_list x) encoder;
+  | Common_types.Bytes_value x ->
+    Pbrt.Encoder.key (7, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.bytes x encoder;
+  end
+
+and encode_array_value (v:Common_types.array_value) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_any_value x) encoder;
+  ) v.Common_types.values;
+  ()
+
+and encode_key_value_list (v:Common_types.key_value_list) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_key_value x) encoder;
+  ) v.Common_types.values;
+  ()
+
+and encode_key_value (v:Common_types.key_value) encoder = 
+  Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Common_types.key encoder;
+  begin match v.Common_types.value with
+  | Some x -> 
+    Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_any_value x) encoder;
+  | None -> ();
+  end;
+  ()
+
+let rec encode_instrumentation_library (v:Common_types.instrumentation_library) encoder = 
+  Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Common_types.name encoder;
+  Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Common_types.version encoder;
+  ()

--- a/src/common_pb.mli
+++ b/src/common_pb.mli
@@ -1,0 +1,37 @@
+(** common.proto Binary Encoding *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_any_value : Common_types.any_value -> Pbrt.Encoder.t -> unit
+(** [encode_any_value v encoder] encodes [v] with the given [encoder] *)
+
+val encode_array_value : Common_types.array_value -> Pbrt.Encoder.t -> unit
+(** [encode_array_value v encoder] encodes [v] with the given [encoder] *)
+
+val encode_key_value_list : Common_types.key_value_list -> Pbrt.Encoder.t -> unit
+(** [encode_key_value_list v encoder] encodes [v] with the given [encoder] *)
+
+val encode_key_value : Common_types.key_value -> Pbrt.Encoder.t -> unit
+(** [encode_key_value v encoder] encodes [v] with the given [encoder] *)
+
+val encode_instrumentation_library : Common_types.instrumentation_library -> Pbrt.Encoder.t -> unit
+(** [encode_instrumentation_library v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_any_value : Pbrt.Decoder.t -> Common_types.any_value
+(** [decode_any_value decoder] decodes a [any_value] value from [decoder] *)
+
+val decode_array_value : Pbrt.Decoder.t -> Common_types.array_value
+(** [decode_array_value decoder] decodes a [array_value] value from [decoder] *)
+
+val decode_key_value_list : Pbrt.Decoder.t -> Common_types.key_value_list
+(** [decode_key_value_list decoder] decodes a [key_value_list] value from [decoder] *)
+
+val decode_key_value : Pbrt.Decoder.t -> Common_types.key_value
+(** [decode_key_value decoder] decodes a [key_value] value from [decoder] *)
+
+val decode_instrumentation_library : Pbrt.Decoder.t -> Common_types.instrumentation_library
+(** [decode_instrumentation_library decoder] decodes a [instrumentation_library] value from [decoder] *)

--- a/src/common_pp.ml
+++ b/src/common_pp.ml
@@ -1,0 +1,37 @@
+[@@@ocaml.warning "-27-30-39"]
+
+let rec pp_any_value fmt (v:Common_types.any_value) =
+  match v with
+  | Common_types.String_value x -> Format.fprintf fmt "@[<hv2>String_value(@,%a)@]" Pbrt.Pp.pp_string x
+  | Common_types.Bool_value x -> Format.fprintf fmt "@[<hv2>Bool_value(@,%a)@]" Pbrt.Pp.pp_bool x
+  | Common_types.Int_value x -> Format.fprintf fmt "@[<hv2>Int_value(@,%a)@]" Pbrt.Pp.pp_int64 x
+  | Common_types.Double_value x -> Format.fprintf fmt "@[<hv2>Double_value(@,%a)@]" Pbrt.Pp.pp_float x
+  | Common_types.Array_value x -> Format.fprintf fmt "@[<hv2>Array_value(@,%a)@]" pp_array_value x
+  | Common_types.Kvlist_value x -> Format.fprintf fmt "@[<hv2>Kvlist_value(@,%a)@]" pp_key_value_list x
+  | Common_types.Bytes_value x -> Format.fprintf fmt "@[<hv2>Bytes_value(@,%a)@]" Pbrt.Pp.pp_bytes x
+
+and pp_array_value fmt (v:Common_types.array_value) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "values" (Pbrt.Pp.pp_list pp_any_value) fmt v.Common_types.values;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+and pp_key_value_list fmt (v:Common_types.key_value_list) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "values" (Pbrt.Pp.pp_list pp_key_value) fmt v.Common_types.values;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+and pp_key_value fmt (v:Common_types.key_value) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "key" Pbrt.Pp.pp_string fmt v.Common_types.key;
+    Pbrt.Pp.pp_record_field ~first:false "value" (Pbrt.Pp.pp_option pp_any_value) fmt v.Common_types.value;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_instrumentation_library fmt (v:Common_types.instrumentation_library) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "name" Pbrt.Pp.pp_string fmt v.Common_types.name;
+    Pbrt.Pp.pp_record_field ~first:false "version" Pbrt.Pp.pp_string fmt v.Common_types.version;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()

--- a/src/common_pp.mli
+++ b/src/common_pp.mli
@@ -1,0 +1,19 @@
+(** common.proto Pretty Printing *)
+
+
+(** {2 Formatters} *)
+
+val pp_any_value : Format.formatter -> Common_types.any_value -> unit 
+(** [pp_any_value v] formats v *)
+
+val pp_array_value : Format.formatter -> Common_types.array_value -> unit 
+(** [pp_array_value v] formats v *)
+
+val pp_key_value_list : Format.formatter -> Common_types.key_value_list -> unit 
+(** [pp_key_value_list v] formats v *)
+
+val pp_key_value : Format.formatter -> Common_types.key_value -> unit 
+(** [pp_key_value v] formats v *)
+
+val pp_instrumentation_library : Format.formatter -> Common_types.instrumentation_library -> unit 
+(** [pp_instrumentation_library v] formats v *)

--- a/src/common_types.ml
+++ b/src/common_types.ml
@@ -1,0 +1,59 @@
+[@@@ocaml.warning "-27-30-39"]
+
+
+type any_value =
+  | String_value of string
+  | Bool_value of bool
+  | Int_value of int64
+  | Double_value of float
+  | Array_value of array_value
+  | Kvlist_value of key_value_list
+  | Bytes_value of bytes
+
+and array_value = {
+  values : any_value list;
+}
+
+and key_value_list = {
+  values : key_value list;
+}
+
+and key_value = {
+  key : string;
+  value : any_value option;
+}
+
+type instrumentation_library = {
+  name : string;
+  version : string;
+}
+
+let rec default_any_value () : any_value = String_value ("")
+
+and default_array_value 
+  ?values:((values:any_value list) = [])
+  () : array_value  = {
+  values;
+}
+
+and default_key_value_list 
+  ?values:((values:key_value list) = [])
+  () : key_value_list  = {
+  values;
+}
+
+and default_key_value 
+  ?key:((key:string) = "")
+  ?value:((value:any_value option) = None)
+  () : key_value  = {
+  key;
+  value;
+}
+
+let rec default_instrumentation_library 
+  ?name:((name:string) = "")
+  ?version:((version:string) = "")
+  () : instrumentation_library  = {
+  name;
+  version;
+}

--- a/src/common_types.mli
+++ b/src/common_types.mli
@@ -1,0 +1,64 @@
+(** common.proto Types *)
+
+
+
+(** {2 Types} *)
+
+type any_value =
+  | String_value of string
+  | Bool_value of bool
+  | Int_value of int64
+  | Double_value of float
+  | Array_value of array_value
+  | Kvlist_value of key_value_list
+  | Bytes_value of bytes
+
+and array_value = {
+  values : any_value list;
+}
+
+and key_value_list = {
+  values : key_value list;
+}
+
+and key_value = {
+  key : string;
+  value : any_value option;
+}
+
+type instrumentation_library = {
+  name : string;
+  version : string;
+}
+
+
+(** {2 Default values} *)
+
+val default_any_value : unit -> any_value
+(** [default_any_value ()] is the default value for type [any_value] *)
+
+val default_array_value : 
+  ?values:any_value list ->
+  unit ->
+  array_value
+(** [default_array_value ()] is the default value for type [array_value] *)
+
+val default_key_value_list : 
+  ?values:key_value list ->
+  unit ->
+  key_value_list
+(** [default_key_value_list ()] is the default value for type [key_value_list] *)
+
+val default_key_value : 
+  ?key:string ->
+  ?value:any_value option ->
+  unit ->
+  key_value
+(** [default_key_value ()] is the default value for type [key_value] *)
+
+val default_instrumentation_library : 
+  ?name:string ->
+  ?version:string ->
+  unit ->
+  instrumentation_library
+(** [default_instrumentation_library ()] is the default value for type [instrumentation_library] *)

--- a/src/dune
+++ b/src/dune
@@ -2,12 +2,14 @@
  (name opentelemetry)
  (synopsis "API for opentelemetry instrumentation")
  (flags :standard -warn-error -a+8)
- (libraries ptime ptime.clock.os ocaml-protoc)
+ (libraries ptime ptime.clock.os pbrt)
  (public_name opentelemetry))
 
 ; ### protobuf rules ###
 
 (rule
+  (alias lint)
+  (mode promote)
   (targets status_types.ml status_types.mli
            status_pb.ml status_pb.mli
            status_pp.ml status_pp.mli)
@@ -16,6 +18,8 @@
   (action (run ocaml-protoc %{file} -ml_out . -pp -binary)))
 
 (rule
+  (alias lint)
+  (mode promote)
   (targets common_types.ml common_types.mli
            common_pb.ml common_pb.mli
            common_pp.ml common_pp.mli)
@@ -27,6 +31,8 @@
                -ml_out . -pp -binary)))
 
 (rule
+  (alias lint)
+  (mode promote)
   (targets resource_types.ml resource_types.mli
            resource_pb.ml resource_pb.mli
            resource_pp.ml resource_pp.mli)
@@ -38,6 +44,8 @@
                -ml_out . -pp -binary)))
 
 (rule
+  (alias lint)
+  (mode promote)
   (targets trace_types.ml trace_types.mli
            trace_pb.ml trace_pb.mli
            trace_pp.ml trace_pp.mli)
@@ -49,6 +57,8 @@
                -ml_out . -pp -binary)))
 
 (rule
+  (alias lint)
+  (mode promote)
   (targets metrics_types.ml metrics_types.mli
            metrics_pb.ml metrics_pb.mli
            metrics_pp.ml metrics_pp.mli)
@@ -60,6 +70,8 @@
                -ml_out . -pp -binary)))
 
 (rule
+  (alias lint)
+  (mode promote)
   (targets metrics_service_types.ml metrics_service_types.mli
            metrics_service_pp.ml metrics_service_pp.mli
            metrics_service_pb.ml metrics_service_pb.mli)
@@ -70,6 +82,8 @@
                -ml_out . -pp -binary)))
 
 (rule
+  (alias lint)
+  (mode promote)
   (targets trace_service_types.ml trace_service_types.mli
            trace_service_pp.ml trace_service_pp.mli
            trace_service_pb.ml trace_service_pb.mli)

--- a/src/metrics_pb.ml
+++ b/src/metrics_pb.ml
@@ -1,0 +1,1208 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type exemplar_mutable = {
+  mutable filtered_attributes : Common_types.key_value list;
+  mutable time_unix_nano : int64;
+  mutable value : Metrics_types.exemplar_value;
+  mutable span_id : bytes;
+  mutable trace_id : bytes;
+}
+
+let default_exemplar_mutable () : exemplar_mutable = {
+  filtered_attributes = [];
+  time_unix_nano = 0L;
+  value = Metrics_types.As_double (0.);
+  span_id = Bytes.create 0;
+  trace_id = Bytes.create 0;
+}
+
+type number_data_point_mutable = {
+  mutable attributes : Common_types.key_value list;
+  mutable start_time_unix_nano : int64;
+  mutable time_unix_nano : int64;
+  mutable value : Metrics_types.number_data_point_value;
+  mutable exemplars : Metrics_types.exemplar list;
+  mutable flags : int32;
+}
+
+let default_number_data_point_mutable () : number_data_point_mutable = {
+  attributes = [];
+  start_time_unix_nano = 0L;
+  time_unix_nano = 0L;
+  value = Metrics_types.As_double (0.);
+  exemplars = [];
+  flags = 0l;
+}
+
+type gauge_mutable = {
+  mutable data_points : Metrics_types.number_data_point list;
+}
+
+let default_gauge_mutable () : gauge_mutable = {
+  data_points = [];
+}
+
+type sum_mutable = {
+  mutable data_points : Metrics_types.number_data_point list;
+  mutable aggregation_temporality : Metrics_types.aggregation_temporality;
+  mutable is_monotonic : bool;
+}
+
+let default_sum_mutable () : sum_mutable = {
+  data_points = [];
+  aggregation_temporality = Metrics_types.default_aggregation_temporality ();
+  is_monotonic = false;
+}
+
+type histogram_data_point_mutable = {
+  mutable attributes : Common_types.key_value list;
+  mutable start_time_unix_nano : int64;
+  mutable time_unix_nano : int64;
+  mutable count : int64;
+  mutable sum : float;
+  mutable bucket_counts : int64 list;
+  mutable explicit_bounds : float list;
+  mutable exemplars : Metrics_types.exemplar list;
+  mutable flags : int32;
+}
+
+let default_histogram_data_point_mutable () : histogram_data_point_mutable = {
+  attributes = [];
+  start_time_unix_nano = 0L;
+  time_unix_nano = 0L;
+  count = 0L;
+  sum = 0.;
+  bucket_counts = [];
+  explicit_bounds = [];
+  exemplars = [];
+  flags = 0l;
+}
+
+type histogram_mutable = {
+  mutable data_points : Metrics_types.histogram_data_point list;
+  mutable aggregation_temporality : Metrics_types.aggregation_temporality;
+}
+
+let default_histogram_mutable () : histogram_mutable = {
+  data_points = [];
+  aggregation_temporality = Metrics_types.default_aggregation_temporality ();
+}
+
+type exponential_histogram_data_point_buckets_mutable = {
+  mutable offset : int32;
+  mutable bucket_counts : int64 list;
+}
+
+let default_exponential_histogram_data_point_buckets_mutable () : exponential_histogram_data_point_buckets_mutable = {
+  offset = 0l;
+  bucket_counts = [];
+}
+
+type exponential_histogram_data_point_mutable = {
+  mutable attributes : Common_types.key_value list;
+  mutable start_time_unix_nano : int64;
+  mutable time_unix_nano : int64;
+  mutable count : int64;
+  mutable sum : float;
+  mutable scale : int32;
+  mutable zero_count : int64;
+  mutable positive : Metrics_types.exponential_histogram_data_point_buckets option;
+  mutable negative : Metrics_types.exponential_histogram_data_point_buckets option;
+  mutable flags : int32;
+  mutable exemplars : Metrics_types.exemplar list;
+}
+
+let default_exponential_histogram_data_point_mutable () : exponential_histogram_data_point_mutable = {
+  attributes = [];
+  start_time_unix_nano = 0L;
+  time_unix_nano = 0L;
+  count = 0L;
+  sum = 0.;
+  scale = 0l;
+  zero_count = 0L;
+  positive = None;
+  negative = None;
+  flags = 0l;
+  exemplars = [];
+}
+
+type exponential_histogram_mutable = {
+  mutable data_points : Metrics_types.exponential_histogram_data_point list;
+  mutable aggregation_temporality : Metrics_types.aggregation_temporality;
+}
+
+let default_exponential_histogram_mutable () : exponential_histogram_mutable = {
+  data_points = [];
+  aggregation_temporality = Metrics_types.default_aggregation_temporality ();
+}
+
+type summary_data_point_value_at_quantile_mutable = {
+  mutable quantile : float;
+  mutable value : float;
+}
+
+let default_summary_data_point_value_at_quantile_mutable () : summary_data_point_value_at_quantile_mutable = {
+  quantile = 0.;
+  value = 0.;
+}
+
+type summary_data_point_mutable = {
+  mutable attributes : Common_types.key_value list;
+  mutable start_time_unix_nano : int64;
+  mutable time_unix_nano : int64;
+  mutable count : int64;
+  mutable sum : float;
+  mutable quantile_values : Metrics_types.summary_data_point_value_at_quantile list;
+  mutable flags : int32;
+}
+
+let default_summary_data_point_mutable () : summary_data_point_mutable = {
+  attributes = [];
+  start_time_unix_nano = 0L;
+  time_unix_nano = 0L;
+  count = 0L;
+  sum = 0.;
+  quantile_values = [];
+  flags = 0l;
+}
+
+type summary_mutable = {
+  mutable data_points : Metrics_types.summary_data_point list;
+}
+
+let default_summary_mutable () : summary_mutable = {
+  data_points = [];
+}
+
+type metric_mutable = {
+  mutable name : string;
+  mutable description : string;
+  mutable unit_ : string;
+  mutable data : Metrics_types.metric_data;
+}
+
+let default_metric_mutable () : metric_mutable = {
+  name = "";
+  description = "";
+  unit_ = "";
+  data = Metrics_types.Gauge (Metrics_types.default_gauge ());
+}
+
+type instrumentation_library_metrics_mutable = {
+  mutable instrumentation_library : Common_types.instrumentation_library option;
+  mutable metrics : Metrics_types.metric list;
+  mutable schema_url : string;
+}
+
+let default_instrumentation_library_metrics_mutable () : instrumentation_library_metrics_mutable = {
+  instrumentation_library = None;
+  metrics = [];
+  schema_url = "";
+}
+
+type resource_metrics_mutable = {
+  mutable resource : Resource_types.resource option;
+  mutable instrumentation_library_metrics : Metrics_types.instrumentation_library_metrics list;
+  mutable schema_url : string;
+}
+
+let default_resource_metrics_mutable () : resource_metrics_mutable = {
+  resource = None;
+  instrumentation_library_metrics = [];
+  schema_url = "";
+}
+
+type metrics_data_mutable = {
+  mutable resource_metrics : Metrics_types.resource_metrics list;
+}
+
+let default_metrics_data_mutable () : metrics_data_mutable = {
+  resource_metrics = [];
+}
+
+
+let rec decode_exemplar_value d = 
+  let rec loop () = 
+    let ret:Metrics_types.exemplar_value = match Pbrt.Decoder.key d with
+      | None -> Pbrt.Decoder.malformed_variant "exemplar_value"
+      | Some (3, _) -> (Metrics_types.As_double (Pbrt.Decoder.float_as_bits64 d) : Metrics_types.exemplar_value) 
+      | Some (6, _) -> (Metrics_types.As_int (Pbrt.Decoder.int64_as_bits64 d) : Metrics_types.exemplar_value) 
+      | Some (n, payload_kind) -> (
+        Pbrt.Decoder.skip d payload_kind; 
+        loop () 
+      )
+    in
+    ret
+  in
+  loop ()
+
+and decode_exemplar d =
+  let v = default_exemplar_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.filtered_attributes <- List.rev v.filtered_attributes;
+    ); continue__ := false
+    | Some (7, Pbrt.Bytes) -> begin
+      v.filtered_attributes <- (Common_pb.decode_key_value (Pbrt.Decoder.nested d)) :: v.filtered_attributes;
+    end
+    | Some (7, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exemplar), field(7)" pk
+    | Some (2, Pbrt.Bits64) -> begin
+      v.time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exemplar), field(2)" pk
+    | Some (3, Pbrt.Bits64) -> begin
+      v.value <- Metrics_types.As_double (Pbrt.Decoder.float_as_bits64 d);
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exemplar), field(3)" pk
+    | Some (6, Pbrt.Bits64) -> begin
+      v.value <- Metrics_types.As_int (Pbrt.Decoder.int64_as_bits64 d);
+    end
+    | Some (6, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exemplar), field(6)" pk
+    | Some (4, Pbrt.Bytes) -> begin
+      v.span_id <- Pbrt.Decoder.bytes d;
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exemplar), field(4)" pk
+    | Some (5, Pbrt.Bytes) -> begin
+      v.trace_id <- Pbrt.Decoder.bytes d;
+    end
+    | Some (5, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exemplar), field(5)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.filtered_attributes = v.filtered_attributes;
+    Metrics_types.time_unix_nano = v.time_unix_nano;
+    Metrics_types.value = v.value;
+    Metrics_types.span_id = v.span_id;
+    Metrics_types.trace_id = v.trace_id;
+  } : Metrics_types.exemplar)
+
+let rec decode_number_data_point_value d = 
+  let rec loop () = 
+    let ret:Metrics_types.number_data_point_value = match Pbrt.Decoder.key d with
+      | None -> Pbrt.Decoder.malformed_variant "number_data_point_value"
+      | Some (4, _) -> (Metrics_types.As_double (Pbrt.Decoder.float_as_bits64 d) : Metrics_types.number_data_point_value) 
+      | Some (6, _) -> (Metrics_types.As_int (Pbrt.Decoder.int64_as_bits64 d) : Metrics_types.number_data_point_value) 
+      | Some (n, payload_kind) -> (
+        Pbrt.Decoder.skip d payload_kind; 
+        loop () 
+      )
+    in
+    ret
+  in
+  loop ()
+
+and decode_number_data_point d =
+  let v = default_number_data_point_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.exemplars <- List.rev v.exemplars;
+      v.attributes <- List.rev v.attributes;
+    ); continue__ := false
+    | Some (7, Pbrt.Bytes) -> begin
+      v.attributes <- (Common_pb.decode_key_value (Pbrt.Decoder.nested d)) :: v.attributes;
+    end
+    | Some (7, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(number_data_point), field(7)" pk
+    | Some (2, Pbrt.Bits64) -> begin
+      v.start_time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(number_data_point), field(2)" pk
+    | Some (3, Pbrt.Bits64) -> begin
+      v.time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(number_data_point), field(3)" pk
+    | Some (4, Pbrt.Bits64) -> begin
+      v.value <- Metrics_types.As_double (Pbrt.Decoder.float_as_bits64 d);
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(number_data_point), field(4)" pk
+    | Some (6, Pbrt.Bits64) -> begin
+      v.value <- Metrics_types.As_int (Pbrt.Decoder.int64_as_bits64 d);
+    end
+    | Some (6, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(number_data_point), field(6)" pk
+    | Some (5, Pbrt.Bytes) -> begin
+      v.exemplars <- (decode_exemplar (Pbrt.Decoder.nested d)) :: v.exemplars;
+    end
+    | Some (5, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(number_data_point), field(5)" pk
+    | Some (8, Pbrt.Varint) -> begin
+      v.flags <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (8, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(number_data_point), field(8)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.attributes = v.attributes;
+    Metrics_types.start_time_unix_nano = v.start_time_unix_nano;
+    Metrics_types.time_unix_nano = v.time_unix_nano;
+    Metrics_types.value = v.value;
+    Metrics_types.exemplars = v.exemplars;
+    Metrics_types.flags = v.flags;
+  } : Metrics_types.number_data_point)
+
+let rec decode_gauge d =
+  let v = default_gauge_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.data_points <- List.rev v.data_points;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.data_points <- (decode_number_data_point (Pbrt.Decoder.nested d)) :: v.data_points;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(gauge), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.data_points = v.data_points;
+  } : Metrics_types.gauge)
+
+let rec decode_aggregation_temporality d = 
+  match Pbrt.Decoder.int_as_varint d with
+  | 0 -> (Metrics_types.Aggregation_temporality_unspecified:Metrics_types.aggregation_temporality)
+  | 1 -> (Metrics_types.Aggregation_temporality_delta:Metrics_types.aggregation_temporality)
+  | 2 -> (Metrics_types.Aggregation_temporality_cumulative:Metrics_types.aggregation_temporality)
+  | _ -> Pbrt.Decoder.malformed_variant "aggregation_temporality"
+
+let rec decode_sum d =
+  let v = default_sum_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.data_points <- List.rev v.data_points;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.data_points <- (decode_number_data_point (Pbrt.Decoder.nested d)) :: v.data_points;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(sum), field(1)" pk
+    | Some (2, Pbrt.Varint) -> begin
+      v.aggregation_temporality <- decode_aggregation_temporality d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(sum), field(2)" pk
+    | Some (3, Pbrt.Varint) -> begin
+      v.is_monotonic <- Pbrt.Decoder.bool d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(sum), field(3)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.data_points = v.data_points;
+    Metrics_types.aggregation_temporality = v.aggregation_temporality;
+    Metrics_types.is_monotonic = v.is_monotonic;
+  } : Metrics_types.sum)
+
+let rec decode_histogram_data_point d =
+  let v = default_histogram_data_point_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.exemplars <- List.rev v.exemplars;
+      v.explicit_bounds <- List.rev v.explicit_bounds;
+      v.bucket_counts <- List.rev v.bucket_counts;
+      v.attributes <- List.rev v.attributes;
+    ); continue__ := false
+    | Some (9, Pbrt.Bytes) -> begin
+      v.attributes <- (Common_pb.decode_key_value (Pbrt.Decoder.nested d)) :: v.attributes;
+    end
+    | Some (9, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram_data_point), field(9)" pk
+    | Some (2, Pbrt.Bits64) -> begin
+      v.start_time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram_data_point), field(2)" pk
+    | Some (3, Pbrt.Bits64) -> begin
+      v.time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram_data_point), field(3)" pk
+    | Some (4, Pbrt.Bits64) -> begin
+      v.count <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram_data_point), field(4)" pk
+    | Some (5, Pbrt.Bits64) -> begin
+      v.sum <- Pbrt.Decoder.float_as_bits64 d;
+    end
+    | Some (5, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram_data_point), field(5)" pk
+    | Some (6, Pbrt.Bytes) -> begin
+      v.bucket_counts <- Pbrt.Decoder.packed_fold (fun l d -> (Pbrt.Decoder.int64_as_bits64 d)::l) [] d;
+    end
+    | Some (6, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram_data_point), field(6)" pk
+    | Some (7, Pbrt.Bytes) -> begin
+      v.explicit_bounds <- Pbrt.Decoder.packed_fold (fun l d -> (Pbrt.Decoder.float_as_bits64 d)::l) [] d;
+    end
+    | Some (7, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram_data_point), field(7)" pk
+    | Some (8, Pbrt.Bytes) -> begin
+      v.exemplars <- (decode_exemplar (Pbrt.Decoder.nested d)) :: v.exemplars;
+    end
+    | Some (8, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram_data_point), field(8)" pk
+    | Some (10, Pbrt.Varint) -> begin
+      v.flags <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (10, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram_data_point), field(10)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.attributes = v.attributes;
+    Metrics_types.start_time_unix_nano = v.start_time_unix_nano;
+    Metrics_types.time_unix_nano = v.time_unix_nano;
+    Metrics_types.count = v.count;
+    Metrics_types.sum = v.sum;
+    Metrics_types.bucket_counts = v.bucket_counts;
+    Metrics_types.explicit_bounds = v.explicit_bounds;
+    Metrics_types.exemplars = v.exemplars;
+    Metrics_types.flags = v.flags;
+  } : Metrics_types.histogram_data_point)
+
+let rec decode_histogram d =
+  let v = default_histogram_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.data_points <- List.rev v.data_points;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.data_points <- (decode_histogram_data_point (Pbrt.Decoder.nested d)) :: v.data_points;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram), field(1)" pk
+    | Some (2, Pbrt.Varint) -> begin
+      v.aggregation_temporality <- decode_aggregation_temporality d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(histogram), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.data_points = v.data_points;
+    Metrics_types.aggregation_temporality = v.aggregation_temporality;
+  } : Metrics_types.histogram)
+
+let rec decode_exponential_histogram_data_point_buckets d =
+  let v = default_exponential_histogram_data_point_buckets_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.bucket_counts <- List.rev v.bucket_counts;
+    ); continue__ := false
+    | Some (1, Pbrt.Varint) -> begin
+      v.offset <- Pbrt.Decoder.int32_as_zigzag d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point_buckets), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.bucket_counts <- Pbrt.Decoder.packed_fold (fun l d -> (Pbrt.Decoder.int64_as_varint d)::l) [] d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point_buckets), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.offset = v.offset;
+    Metrics_types.bucket_counts = v.bucket_counts;
+  } : Metrics_types.exponential_histogram_data_point_buckets)
+
+let rec decode_exponential_histogram_data_point d =
+  let v = default_exponential_histogram_data_point_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.exemplars <- List.rev v.exemplars;
+      v.attributes <- List.rev v.attributes;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.attributes <- (Common_pb.decode_key_value (Pbrt.Decoder.nested d)) :: v.attributes;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(1)" pk
+    | Some (2, Pbrt.Bits64) -> begin
+      v.start_time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(2)" pk
+    | Some (3, Pbrt.Bits64) -> begin
+      v.time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(3)" pk
+    | Some (4, Pbrt.Bits64) -> begin
+      v.count <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(4)" pk
+    | Some (5, Pbrt.Bits64) -> begin
+      v.sum <- Pbrt.Decoder.float_as_bits64 d;
+    end
+    | Some (5, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(5)" pk
+    | Some (6, Pbrt.Varint) -> begin
+      v.scale <- Pbrt.Decoder.int32_as_zigzag d;
+    end
+    | Some (6, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(6)" pk
+    | Some (7, Pbrt.Bits64) -> begin
+      v.zero_count <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (7, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(7)" pk
+    | Some (8, Pbrt.Bytes) -> begin
+      v.positive <- Some (decode_exponential_histogram_data_point_buckets (Pbrt.Decoder.nested d));
+    end
+    | Some (8, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(8)" pk
+    | Some (9, Pbrt.Bytes) -> begin
+      v.negative <- Some (decode_exponential_histogram_data_point_buckets (Pbrt.Decoder.nested d));
+    end
+    | Some (9, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(9)" pk
+    | Some (10, Pbrt.Varint) -> begin
+      v.flags <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (10, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(10)" pk
+    | Some (11, Pbrt.Bytes) -> begin
+      v.exemplars <- (decode_exemplar (Pbrt.Decoder.nested d)) :: v.exemplars;
+    end
+    | Some (11, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram_data_point), field(11)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.attributes = v.attributes;
+    Metrics_types.start_time_unix_nano = v.start_time_unix_nano;
+    Metrics_types.time_unix_nano = v.time_unix_nano;
+    Metrics_types.count = v.count;
+    Metrics_types.sum = v.sum;
+    Metrics_types.scale = v.scale;
+    Metrics_types.zero_count = v.zero_count;
+    Metrics_types.positive = v.positive;
+    Metrics_types.negative = v.negative;
+    Metrics_types.flags = v.flags;
+    Metrics_types.exemplars = v.exemplars;
+  } : Metrics_types.exponential_histogram_data_point)
+
+let rec decode_exponential_histogram d =
+  let v = default_exponential_histogram_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.data_points <- List.rev v.data_points;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.data_points <- (decode_exponential_histogram_data_point (Pbrt.Decoder.nested d)) :: v.data_points;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram), field(1)" pk
+    | Some (2, Pbrt.Varint) -> begin
+      v.aggregation_temporality <- decode_aggregation_temporality d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(exponential_histogram), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.data_points = v.data_points;
+    Metrics_types.aggregation_temporality = v.aggregation_temporality;
+  } : Metrics_types.exponential_histogram)
+
+let rec decode_summary_data_point_value_at_quantile d =
+  let v = default_summary_data_point_value_at_quantile_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Bits64) -> begin
+      v.quantile <- Pbrt.Decoder.float_as_bits64 d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(summary_data_point_value_at_quantile), field(1)" pk
+    | Some (2, Pbrt.Bits64) -> begin
+      v.value <- Pbrt.Decoder.float_as_bits64 d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(summary_data_point_value_at_quantile), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.quantile = v.quantile;
+    Metrics_types.value = v.value;
+  } : Metrics_types.summary_data_point_value_at_quantile)
+
+let rec decode_summary_data_point d =
+  let v = default_summary_data_point_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.quantile_values <- List.rev v.quantile_values;
+      v.attributes <- List.rev v.attributes;
+    ); continue__ := false
+    | Some (7, Pbrt.Bytes) -> begin
+      v.attributes <- (Common_pb.decode_key_value (Pbrt.Decoder.nested d)) :: v.attributes;
+    end
+    | Some (7, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(summary_data_point), field(7)" pk
+    | Some (2, Pbrt.Bits64) -> begin
+      v.start_time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(summary_data_point), field(2)" pk
+    | Some (3, Pbrt.Bits64) -> begin
+      v.time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(summary_data_point), field(3)" pk
+    | Some (4, Pbrt.Bits64) -> begin
+      v.count <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(summary_data_point), field(4)" pk
+    | Some (5, Pbrt.Bits64) -> begin
+      v.sum <- Pbrt.Decoder.float_as_bits64 d;
+    end
+    | Some (5, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(summary_data_point), field(5)" pk
+    | Some (6, Pbrt.Bytes) -> begin
+      v.quantile_values <- (decode_summary_data_point_value_at_quantile (Pbrt.Decoder.nested d)) :: v.quantile_values;
+    end
+    | Some (6, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(summary_data_point), field(6)" pk
+    | Some (8, Pbrt.Varint) -> begin
+      v.flags <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (8, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(summary_data_point), field(8)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.attributes = v.attributes;
+    Metrics_types.start_time_unix_nano = v.start_time_unix_nano;
+    Metrics_types.time_unix_nano = v.time_unix_nano;
+    Metrics_types.count = v.count;
+    Metrics_types.sum = v.sum;
+    Metrics_types.quantile_values = v.quantile_values;
+    Metrics_types.flags = v.flags;
+  } : Metrics_types.summary_data_point)
+
+let rec decode_summary d =
+  let v = default_summary_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.data_points <- List.rev v.data_points;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.data_points <- (decode_summary_data_point (Pbrt.Decoder.nested d)) :: v.data_points;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(summary), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.data_points = v.data_points;
+  } : Metrics_types.summary)
+
+let rec decode_metric_data d = 
+  let rec loop () = 
+    let ret:Metrics_types.metric_data = match Pbrt.Decoder.key d with
+      | None -> Pbrt.Decoder.malformed_variant "metric_data"
+      | Some (5, _) -> (Metrics_types.Gauge (decode_gauge (Pbrt.Decoder.nested d)) : Metrics_types.metric_data) 
+      | Some (7, _) -> (Metrics_types.Sum (decode_sum (Pbrt.Decoder.nested d)) : Metrics_types.metric_data) 
+      | Some (9, _) -> (Metrics_types.Histogram (decode_histogram (Pbrt.Decoder.nested d)) : Metrics_types.metric_data) 
+      | Some (10, _) -> (Metrics_types.Exponential_histogram (decode_exponential_histogram (Pbrt.Decoder.nested d)) : Metrics_types.metric_data) 
+      | Some (11, _) -> (Metrics_types.Summary (decode_summary (Pbrt.Decoder.nested d)) : Metrics_types.metric_data) 
+      | Some (n, payload_kind) -> (
+        Pbrt.Decoder.skip d payload_kind; 
+        loop () 
+      )
+    in
+    ret
+  in
+  loop ()
+
+and decode_metric d =
+  let v = default_metric_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.name <- Pbrt.Decoder.string d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(metric), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.description <- Pbrt.Decoder.string d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(metric), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.unit_ <- Pbrt.Decoder.string d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(metric), field(3)" pk
+    | Some (5, Pbrt.Bytes) -> begin
+      v.data <- Metrics_types.Gauge (decode_gauge (Pbrt.Decoder.nested d));
+    end
+    | Some (5, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(metric), field(5)" pk
+    | Some (7, Pbrt.Bytes) -> begin
+      v.data <- Metrics_types.Sum (decode_sum (Pbrt.Decoder.nested d));
+    end
+    | Some (7, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(metric), field(7)" pk
+    | Some (9, Pbrt.Bytes) -> begin
+      v.data <- Metrics_types.Histogram (decode_histogram (Pbrt.Decoder.nested d));
+    end
+    | Some (9, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(metric), field(9)" pk
+    | Some (10, Pbrt.Bytes) -> begin
+      v.data <- Metrics_types.Exponential_histogram (decode_exponential_histogram (Pbrt.Decoder.nested d));
+    end
+    | Some (10, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(metric), field(10)" pk
+    | Some (11, Pbrt.Bytes) -> begin
+      v.data <- Metrics_types.Summary (decode_summary (Pbrt.Decoder.nested d));
+    end
+    | Some (11, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(metric), field(11)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.name = v.name;
+    Metrics_types.description = v.description;
+    Metrics_types.unit_ = v.unit_;
+    Metrics_types.data = v.data;
+  } : Metrics_types.metric)
+
+let rec decode_instrumentation_library_metrics d =
+  let v = default_instrumentation_library_metrics_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.metrics <- List.rev v.metrics;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.instrumentation_library <- Some (Common_pb.decode_instrumentation_library (Pbrt.Decoder.nested d));
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(instrumentation_library_metrics), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.metrics <- (decode_metric (Pbrt.Decoder.nested d)) :: v.metrics;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(instrumentation_library_metrics), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.schema_url <- Pbrt.Decoder.string d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(instrumentation_library_metrics), field(3)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.instrumentation_library = v.instrumentation_library;
+    Metrics_types.metrics = v.metrics;
+    Metrics_types.schema_url = v.schema_url;
+  } : Metrics_types.instrumentation_library_metrics)
+
+let rec decode_resource_metrics d =
+  let v = default_resource_metrics_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.instrumentation_library_metrics <- List.rev v.instrumentation_library_metrics;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.resource <- Some (Resource_pb.decode_resource (Pbrt.Decoder.nested d));
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(resource_metrics), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.instrumentation_library_metrics <- (decode_instrumentation_library_metrics (Pbrt.Decoder.nested d)) :: v.instrumentation_library_metrics;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(resource_metrics), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.schema_url <- Pbrt.Decoder.string d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(resource_metrics), field(3)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.resource = v.resource;
+    Metrics_types.instrumentation_library_metrics = v.instrumentation_library_metrics;
+    Metrics_types.schema_url = v.schema_url;
+  } : Metrics_types.resource_metrics)
+
+let rec decode_metrics_data d =
+  let v = default_metrics_data_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.resource_metrics <- List.rev v.resource_metrics;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.resource_metrics <- (decode_resource_metrics (Pbrt.Decoder.nested d)) :: v.resource_metrics;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(metrics_data), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_types.resource_metrics = v.resource_metrics;
+  } : Metrics_types.metrics_data)
+
+let rec decode_data_point_flags d = 
+  match Pbrt.Decoder.int_as_varint d with
+  | 0 -> (Metrics_types.Flag_none:Metrics_types.data_point_flags)
+  | 1 -> (Metrics_types.Flag_no_recorded_value:Metrics_types.data_point_flags)
+  | _ -> Pbrt.Decoder.malformed_variant "data_point_flags"
+
+let rec encode_exemplar_value (v:Metrics_types.exemplar_value) encoder = 
+  begin match v with
+  | Metrics_types.As_double x ->
+    Pbrt.Encoder.key (3, Pbrt.Bits64) encoder; 
+    Pbrt.Encoder.float_as_bits64 x encoder;
+  | Metrics_types.As_int x ->
+    Pbrt.Encoder.key (6, Pbrt.Bits64) encoder; 
+    Pbrt.Encoder.int64_as_bits64 x encoder;
+  end
+
+and encode_exemplar (v:Metrics_types.exemplar) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (7, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_key_value x) encoder;
+  ) v.Metrics_types.filtered_attributes;
+  Pbrt.Encoder.key (2, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.time_unix_nano encoder;
+  begin match v.Metrics_types.value with
+  | Metrics_types.As_double x ->
+    Pbrt.Encoder.key (3, Pbrt.Bits64) encoder; 
+    Pbrt.Encoder.float_as_bits64 x encoder;
+  | Metrics_types.As_int x ->
+    Pbrt.Encoder.key (6, Pbrt.Bits64) encoder; 
+    Pbrt.Encoder.int64_as_bits64 x encoder;
+  end;
+  Pbrt.Encoder.key (4, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.bytes v.Metrics_types.span_id encoder;
+  Pbrt.Encoder.key (5, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.bytes v.Metrics_types.trace_id encoder;
+  ()
+
+let rec encode_number_data_point_value (v:Metrics_types.number_data_point_value) encoder = 
+  begin match v with
+  | Metrics_types.As_double x ->
+    Pbrt.Encoder.key (4, Pbrt.Bits64) encoder; 
+    Pbrt.Encoder.float_as_bits64 x encoder;
+  | Metrics_types.As_int x ->
+    Pbrt.Encoder.key (6, Pbrt.Bits64) encoder; 
+    Pbrt.Encoder.int64_as_bits64 x encoder;
+  end
+
+and encode_number_data_point (v:Metrics_types.number_data_point) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (7, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_key_value x) encoder;
+  ) v.Metrics_types.attributes;
+  Pbrt.Encoder.key (2, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.start_time_unix_nano encoder;
+  Pbrt.Encoder.key (3, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.time_unix_nano encoder;
+  begin match v.Metrics_types.value with
+  | Metrics_types.As_double x ->
+    Pbrt.Encoder.key (4, Pbrt.Bits64) encoder; 
+    Pbrt.Encoder.float_as_bits64 x encoder;
+  | Metrics_types.As_int x ->
+    Pbrt.Encoder.key (6, Pbrt.Bits64) encoder; 
+    Pbrt.Encoder.int64_as_bits64 x encoder;
+  end;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (5, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_exemplar x) encoder;
+  ) v.Metrics_types.exemplars;
+  Pbrt.Encoder.key (8, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Metrics_types.flags encoder;
+  ()
+
+let rec encode_gauge (v:Metrics_types.gauge) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_number_data_point x) encoder;
+  ) v.Metrics_types.data_points;
+  ()
+
+let rec encode_aggregation_temporality (v:Metrics_types.aggregation_temporality) encoder =
+  match v with
+  | Metrics_types.Aggregation_temporality_unspecified -> Pbrt.Encoder.int_as_varint (0) encoder
+  | Metrics_types.Aggregation_temporality_delta -> Pbrt.Encoder.int_as_varint 1 encoder
+  | Metrics_types.Aggregation_temporality_cumulative -> Pbrt.Encoder.int_as_varint 2 encoder
+
+let rec encode_sum (v:Metrics_types.sum) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_number_data_point x) encoder;
+  ) v.Metrics_types.data_points;
+  Pbrt.Encoder.key (2, Pbrt.Varint) encoder; 
+  encode_aggregation_temporality v.Metrics_types.aggregation_temporality encoder;
+  Pbrt.Encoder.key (3, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.bool v.Metrics_types.is_monotonic encoder;
+  ()
+
+let rec encode_histogram_data_point (v:Metrics_types.histogram_data_point) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (9, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_key_value x) encoder;
+  ) v.Metrics_types.attributes;
+  Pbrt.Encoder.key (2, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.start_time_unix_nano encoder;
+  Pbrt.Encoder.key (3, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.time_unix_nano encoder;
+  Pbrt.Encoder.key (4, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.count encoder;
+  Pbrt.Encoder.key (5, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.float_as_bits64 v.Metrics_types.sum encoder;
+  Pbrt.Encoder.key (6, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.nested (fun encoder ->
+    List.iter (fun x -> 
+      Pbrt.Encoder.int64_as_bits64 x encoder;
+    ) v.Metrics_types.bucket_counts;
+  ) encoder;
+  Pbrt.Encoder.key (7, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.nested (fun encoder ->
+    List.iter (fun x -> 
+      Pbrt.Encoder.float_as_bits64 x encoder;
+    ) v.Metrics_types.explicit_bounds;
+  ) encoder;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (8, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_exemplar x) encoder;
+  ) v.Metrics_types.exemplars;
+  Pbrt.Encoder.key (10, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Metrics_types.flags encoder;
+  ()
+
+let rec encode_histogram (v:Metrics_types.histogram) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_histogram_data_point x) encoder;
+  ) v.Metrics_types.data_points;
+  Pbrt.Encoder.key (2, Pbrt.Varint) encoder; 
+  encode_aggregation_temporality v.Metrics_types.aggregation_temporality encoder;
+  ()
+
+let rec encode_exponential_histogram_data_point_buckets (v:Metrics_types.exponential_histogram_data_point_buckets) encoder = 
+  Pbrt.Encoder.key (1, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_zigzag v.Metrics_types.offset encoder;
+  Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.nested (fun encoder ->
+    List.iter (fun x -> 
+      Pbrt.Encoder.int64_as_varint x encoder;
+    ) v.Metrics_types.bucket_counts;
+  ) encoder;
+  ()
+
+let rec encode_exponential_histogram_data_point (v:Metrics_types.exponential_histogram_data_point) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_key_value x) encoder;
+  ) v.Metrics_types.attributes;
+  Pbrt.Encoder.key (2, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.start_time_unix_nano encoder;
+  Pbrt.Encoder.key (3, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.time_unix_nano encoder;
+  Pbrt.Encoder.key (4, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.count encoder;
+  Pbrt.Encoder.key (5, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.float_as_bits64 v.Metrics_types.sum encoder;
+  Pbrt.Encoder.key (6, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_zigzag v.Metrics_types.scale encoder;
+  Pbrt.Encoder.key (7, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.zero_count encoder;
+  begin match v.Metrics_types.positive with
+  | Some x -> 
+    Pbrt.Encoder.key (8, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_exponential_histogram_data_point_buckets x) encoder;
+  | None -> ();
+  end;
+  begin match v.Metrics_types.negative with
+  | Some x -> 
+    Pbrt.Encoder.key (9, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_exponential_histogram_data_point_buckets x) encoder;
+  | None -> ();
+  end;
+  Pbrt.Encoder.key (10, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Metrics_types.flags encoder;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (11, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_exemplar x) encoder;
+  ) v.Metrics_types.exemplars;
+  ()
+
+let rec encode_exponential_histogram (v:Metrics_types.exponential_histogram) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_exponential_histogram_data_point x) encoder;
+  ) v.Metrics_types.data_points;
+  Pbrt.Encoder.key (2, Pbrt.Varint) encoder; 
+  encode_aggregation_temporality v.Metrics_types.aggregation_temporality encoder;
+  ()
+
+let rec encode_summary_data_point_value_at_quantile (v:Metrics_types.summary_data_point_value_at_quantile) encoder = 
+  Pbrt.Encoder.key (1, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.float_as_bits64 v.Metrics_types.quantile encoder;
+  Pbrt.Encoder.key (2, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.float_as_bits64 v.Metrics_types.value encoder;
+  ()
+
+let rec encode_summary_data_point (v:Metrics_types.summary_data_point) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (7, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_key_value x) encoder;
+  ) v.Metrics_types.attributes;
+  Pbrt.Encoder.key (2, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.start_time_unix_nano encoder;
+  Pbrt.Encoder.key (3, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.time_unix_nano encoder;
+  Pbrt.Encoder.key (4, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Metrics_types.count encoder;
+  Pbrt.Encoder.key (5, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.float_as_bits64 v.Metrics_types.sum encoder;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (6, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_summary_data_point_value_at_quantile x) encoder;
+  ) v.Metrics_types.quantile_values;
+  Pbrt.Encoder.key (8, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Metrics_types.flags encoder;
+  ()
+
+let rec encode_summary (v:Metrics_types.summary) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_summary_data_point x) encoder;
+  ) v.Metrics_types.data_points;
+  ()
+
+let rec encode_metric_data (v:Metrics_types.metric_data) encoder = 
+  begin match v with
+  | Metrics_types.Gauge x ->
+    Pbrt.Encoder.key (5, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_gauge x) encoder;
+  | Metrics_types.Sum x ->
+    Pbrt.Encoder.key (7, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_sum x) encoder;
+  | Metrics_types.Histogram x ->
+    Pbrt.Encoder.key (9, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_histogram x) encoder;
+  | Metrics_types.Exponential_histogram x ->
+    Pbrt.Encoder.key (10, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_exponential_histogram x) encoder;
+  | Metrics_types.Summary x ->
+    Pbrt.Encoder.key (11, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_summary x) encoder;
+  end
+
+and encode_metric (v:Metrics_types.metric) encoder = 
+  Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Metrics_types.name encoder;
+  Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Metrics_types.description encoder;
+  Pbrt.Encoder.key (3, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Metrics_types.unit_ encoder;
+  begin match v.Metrics_types.data with
+  | Metrics_types.Gauge x ->
+    Pbrt.Encoder.key (5, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_gauge x) encoder;
+  | Metrics_types.Sum x ->
+    Pbrt.Encoder.key (7, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_sum x) encoder;
+  | Metrics_types.Histogram x ->
+    Pbrt.Encoder.key (9, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_histogram x) encoder;
+  | Metrics_types.Exponential_histogram x ->
+    Pbrt.Encoder.key (10, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_exponential_histogram x) encoder;
+  | Metrics_types.Summary x ->
+    Pbrt.Encoder.key (11, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_summary x) encoder;
+  end;
+  ()
+
+let rec encode_instrumentation_library_metrics (v:Metrics_types.instrumentation_library_metrics) encoder = 
+  begin match v.Metrics_types.instrumentation_library with
+  | Some x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_instrumentation_library x) encoder;
+  | None -> ();
+  end;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_metric x) encoder;
+  ) v.Metrics_types.metrics;
+  Pbrt.Encoder.key (3, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Metrics_types.schema_url encoder;
+  ()
+
+let rec encode_resource_metrics (v:Metrics_types.resource_metrics) encoder = 
+  begin match v.Metrics_types.resource with
+  | Some x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Resource_pb.encode_resource x) encoder;
+  | None -> ();
+  end;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_instrumentation_library_metrics x) encoder;
+  ) v.Metrics_types.instrumentation_library_metrics;
+  Pbrt.Encoder.key (3, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Metrics_types.schema_url encoder;
+  ()
+
+let rec encode_metrics_data (v:Metrics_types.metrics_data) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_resource_metrics x) encoder;
+  ) v.Metrics_types.resource_metrics;
+  ()
+
+let rec encode_data_point_flags (v:Metrics_types.data_point_flags) encoder =
+  match v with
+  | Metrics_types.Flag_none -> Pbrt.Encoder.int_as_varint (0) encoder
+  | Metrics_types.Flag_no_recorded_value -> Pbrt.Encoder.int_as_varint 1 encoder

--- a/src/metrics_pb.mli
+++ b/src/metrics_pb.mli
@@ -1,0 +1,133 @@
+(** metrics.proto Binary Encoding *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_exemplar_value : Metrics_types.exemplar_value -> Pbrt.Encoder.t -> unit
+(** [encode_exemplar_value v encoder] encodes [v] with the given [encoder] *)
+
+val encode_exemplar : Metrics_types.exemplar -> Pbrt.Encoder.t -> unit
+(** [encode_exemplar v encoder] encodes [v] with the given [encoder] *)
+
+val encode_number_data_point_value : Metrics_types.number_data_point_value -> Pbrt.Encoder.t -> unit
+(** [encode_number_data_point_value v encoder] encodes [v] with the given [encoder] *)
+
+val encode_number_data_point : Metrics_types.number_data_point -> Pbrt.Encoder.t -> unit
+(** [encode_number_data_point v encoder] encodes [v] with the given [encoder] *)
+
+val encode_gauge : Metrics_types.gauge -> Pbrt.Encoder.t -> unit
+(** [encode_gauge v encoder] encodes [v] with the given [encoder] *)
+
+val encode_aggregation_temporality : Metrics_types.aggregation_temporality -> Pbrt.Encoder.t -> unit
+(** [encode_aggregation_temporality v encoder] encodes [v] with the given [encoder] *)
+
+val encode_sum : Metrics_types.sum -> Pbrt.Encoder.t -> unit
+(** [encode_sum v encoder] encodes [v] with the given [encoder] *)
+
+val encode_histogram_data_point : Metrics_types.histogram_data_point -> Pbrt.Encoder.t -> unit
+(** [encode_histogram_data_point v encoder] encodes [v] with the given [encoder] *)
+
+val encode_histogram : Metrics_types.histogram -> Pbrt.Encoder.t -> unit
+(** [encode_histogram v encoder] encodes [v] with the given [encoder] *)
+
+val encode_exponential_histogram_data_point_buckets : Metrics_types.exponential_histogram_data_point_buckets -> Pbrt.Encoder.t -> unit
+(** [encode_exponential_histogram_data_point_buckets v encoder] encodes [v] with the given [encoder] *)
+
+val encode_exponential_histogram_data_point : Metrics_types.exponential_histogram_data_point -> Pbrt.Encoder.t -> unit
+(** [encode_exponential_histogram_data_point v encoder] encodes [v] with the given [encoder] *)
+
+val encode_exponential_histogram : Metrics_types.exponential_histogram -> Pbrt.Encoder.t -> unit
+(** [encode_exponential_histogram v encoder] encodes [v] with the given [encoder] *)
+
+val encode_summary_data_point_value_at_quantile : Metrics_types.summary_data_point_value_at_quantile -> Pbrt.Encoder.t -> unit
+(** [encode_summary_data_point_value_at_quantile v encoder] encodes [v] with the given [encoder] *)
+
+val encode_summary_data_point : Metrics_types.summary_data_point -> Pbrt.Encoder.t -> unit
+(** [encode_summary_data_point v encoder] encodes [v] with the given [encoder] *)
+
+val encode_summary : Metrics_types.summary -> Pbrt.Encoder.t -> unit
+(** [encode_summary v encoder] encodes [v] with the given [encoder] *)
+
+val encode_metric_data : Metrics_types.metric_data -> Pbrt.Encoder.t -> unit
+(** [encode_metric_data v encoder] encodes [v] with the given [encoder] *)
+
+val encode_metric : Metrics_types.metric -> Pbrt.Encoder.t -> unit
+(** [encode_metric v encoder] encodes [v] with the given [encoder] *)
+
+val encode_instrumentation_library_metrics : Metrics_types.instrumentation_library_metrics -> Pbrt.Encoder.t -> unit
+(** [encode_instrumentation_library_metrics v encoder] encodes [v] with the given [encoder] *)
+
+val encode_resource_metrics : Metrics_types.resource_metrics -> Pbrt.Encoder.t -> unit
+(** [encode_resource_metrics v encoder] encodes [v] with the given [encoder] *)
+
+val encode_metrics_data : Metrics_types.metrics_data -> Pbrt.Encoder.t -> unit
+(** [encode_metrics_data v encoder] encodes [v] with the given [encoder] *)
+
+val encode_data_point_flags : Metrics_types.data_point_flags -> Pbrt.Encoder.t -> unit
+(** [encode_data_point_flags v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_exemplar_value : Pbrt.Decoder.t -> Metrics_types.exemplar_value
+(** [decode_exemplar_value decoder] decodes a [exemplar_value] value from [decoder] *)
+
+val decode_exemplar : Pbrt.Decoder.t -> Metrics_types.exemplar
+(** [decode_exemplar decoder] decodes a [exemplar] value from [decoder] *)
+
+val decode_number_data_point_value : Pbrt.Decoder.t -> Metrics_types.number_data_point_value
+(** [decode_number_data_point_value decoder] decodes a [number_data_point_value] value from [decoder] *)
+
+val decode_number_data_point : Pbrt.Decoder.t -> Metrics_types.number_data_point
+(** [decode_number_data_point decoder] decodes a [number_data_point] value from [decoder] *)
+
+val decode_gauge : Pbrt.Decoder.t -> Metrics_types.gauge
+(** [decode_gauge decoder] decodes a [gauge] value from [decoder] *)
+
+val decode_aggregation_temporality : Pbrt.Decoder.t -> Metrics_types.aggregation_temporality
+(** [decode_aggregation_temporality decoder] decodes a [aggregation_temporality] value from [decoder] *)
+
+val decode_sum : Pbrt.Decoder.t -> Metrics_types.sum
+(** [decode_sum decoder] decodes a [sum] value from [decoder] *)
+
+val decode_histogram_data_point : Pbrt.Decoder.t -> Metrics_types.histogram_data_point
+(** [decode_histogram_data_point decoder] decodes a [histogram_data_point] value from [decoder] *)
+
+val decode_histogram : Pbrt.Decoder.t -> Metrics_types.histogram
+(** [decode_histogram decoder] decodes a [histogram] value from [decoder] *)
+
+val decode_exponential_histogram_data_point_buckets : Pbrt.Decoder.t -> Metrics_types.exponential_histogram_data_point_buckets
+(** [decode_exponential_histogram_data_point_buckets decoder] decodes a [exponential_histogram_data_point_buckets] value from [decoder] *)
+
+val decode_exponential_histogram_data_point : Pbrt.Decoder.t -> Metrics_types.exponential_histogram_data_point
+(** [decode_exponential_histogram_data_point decoder] decodes a [exponential_histogram_data_point] value from [decoder] *)
+
+val decode_exponential_histogram : Pbrt.Decoder.t -> Metrics_types.exponential_histogram
+(** [decode_exponential_histogram decoder] decodes a [exponential_histogram] value from [decoder] *)
+
+val decode_summary_data_point_value_at_quantile : Pbrt.Decoder.t -> Metrics_types.summary_data_point_value_at_quantile
+(** [decode_summary_data_point_value_at_quantile decoder] decodes a [summary_data_point_value_at_quantile] value from [decoder] *)
+
+val decode_summary_data_point : Pbrt.Decoder.t -> Metrics_types.summary_data_point
+(** [decode_summary_data_point decoder] decodes a [summary_data_point] value from [decoder] *)
+
+val decode_summary : Pbrt.Decoder.t -> Metrics_types.summary
+(** [decode_summary decoder] decodes a [summary] value from [decoder] *)
+
+val decode_metric_data : Pbrt.Decoder.t -> Metrics_types.metric_data
+(** [decode_metric_data decoder] decodes a [metric_data] value from [decoder] *)
+
+val decode_metric : Pbrt.Decoder.t -> Metrics_types.metric
+(** [decode_metric decoder] decodes a [metric] value from [decoder] *)
+
+val decode_instrumentation_library_metrics : Pbrt.Decoder.t -> Metrics_types.instrumentation_library_metrics
+(** [decode_instrumentation_library_metrics decoder] decodes a [instrumentation_library_metrics] value from [decoder] *)
+
+val decode_resource_metrics : Pbrt.Decoder.t -> Metrics_types.resource_metrics
+(** [decode_resource_metrics decoder] decodes a [resource_metrics] value from [decoder] *)
+
+val decode_metrics_data : Pbrt.Decoder.t -> Metrics_types.metrics_data
+(** [decode_metrics_data decoder] decodes a [metrics_data] value from [decoder] *)
+
+val decode_data_point_flags : Pbrt.Decoder.t -> Metrics_types.data_point_flags
+(** [decode_data_point_flags decoder] decodes a [data_point_flags] value from [decoder] *)

--- a/src/metrics_pp.ml
+++ b/src/metrics_pp.ml
@@ -1,0 +1,172 @@
+[@@@ocaml.warning "-27-30-39"]
+
+let rec pp_exemplar_value fmt (v:Metrics_types.exemplar_value) =
+  match v with
+  | Metrics_types.As_double x -> Format.fprintf fmt "@[<hv2>As_double(@,%a)@]" Pbrt.Pp.pp_float x
+  | Metrics_types.As_int x -> Format.fprintf fmt "@[<hv2>As_int(@,%a)@]" Pbrt.Pp.pp_int64 x
+
+and pp_exemplar fmt (v:Metrics_types.exemplar) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "filtered_attributes" (Pbrt.Pp.pp_list Common_pp.pp_key_value) fmt v.Metrics_types.filtered_attributes;
+    Pbrt.Pp.pp_record_field ~first:false "time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Metrics_types.time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "value" pp_exemplar_value fmt v.Metrics_types.value;
+    Pbrt.Pp.pp_record_field ~first:false "span_id" Pbrt.Pp.pp_bytes fmt v.Metrics_types.span_id;
+    Pbrt.Pp.pp_record_field ~first:false "trace_id" Pbrt.Pp.pp_bytes fmt v.Metrics_types.trace_id;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_number_data_point_value fmt (v:Metrics_types.number_data_point_value) =
+  match v with
+  | Metrics_types.As_double x -> Format.fprintf fmt "@[<hv2>As_double(@,%a)@]" Pbrt.Pp.pp_float x
+  | Metrics_types.As_int x -> Format.fprintf fmt "@[<hv2>As_int(@,%a)@]" Pbrt.Pp.pp_int64 x
+
+and pp_number_data_point fmt (v:Metrics_types.number_data_point) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "attributes" (Pbrt.Pp.pp_list Common_pp.pp_key_value) fmt v.Metrics_types.attributes;
+    Pbrt.Pp.pp_record_field ~first:false "start_time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Metrics_types.start_time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Metrics_types.time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "value" pp_number_data_point_value fmt v.Metrics_types.value;
+    Pbrt.Pp.pp_record_field ~first:false "exemplars" (Pbrt.Pp.pp_list pp_exemplar) fmt v.Metrics_types.exemplars;
+    Pbrt.Pp.pp_record_field ~first:false "flags" Pbrt.Pp.pp_int32 fmt v.Metrics_types.flags;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_gauge fmt (v:Metrics_types.gauge) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "data_points" (Pbrt.Pp.pp_list pp_number_data_point) fmt v.Metrics_types.data_points;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_aggregation_temporality fmt (v:Metrics_types.aggregation_temporality) =
+  match v with
+  | Metrics_types.Aggregation_temporality_unspecified -> Format.fprintf fmt "Aggregation_temporality_unspecified"
+  | Metrics_types.Aggregation_temporality_delta -> Format.fprintf fmt "Aggregation_temporality_delta"
+  | Metrics_types.Aggregation_temporality_cumulative -> Format.fprintf fmt "Aggregation_temporality_cumulative"
+
+let rec pp_sum fmt (v:Metrics_types.sum) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "data_points" (Pbrt.Pp.pp_list pp_number_data_point) fmt v.Metrics_types.data_points;
+    Pbrt.Pp.pp_record_field ~first:false "aggregation_temporality" pp_aggregation_temporality fmt v.Metrics_types.aggregation_temporality;
+    Pbrt.Pp.pp_record_field ~first:false "is_monotonic" Pbrt.Pp.pp_bool fmt v.Metrics_types.is_monotonic;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_histogram_data_point fmt (v:Metrics_types.histogram_data_point) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "attributes" (Pbrt.Pp.pp_list Common_pp.pp_key_value) fmt v.Metrics_types.attributes;
+    Pbrt.Pp.pp_record_field ~first:false "start_time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Metrics_types.start_time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Metrics_types.time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "count" Pbrt.Pp.pp_int64 fmt v.Metrics_types.count;
+    Pbrt.Pp.pp_record_field ~first:false "sum" Pbrt.Pp.pp_float fmt v.Metrics_types.sum;
+    Pbrt.Pp.pp_record_field ~first:false "bucket_counts" (Pbrt.Pp.pp_list Pbrt.Pp.pp_int64) fmt v.Metrics_types.bucket_counts;
+    Pbrt.Pp.pp_record_field ~first:false "explicit_bounds" (Pbrt.Pp.pp_list Pbrt.Pp.pp_float) fmt v.Metrics_types.explicit_bounds;
+    Pbrt.Pp.pp_record_field ~first:false "exemplars" (Pbrt.Pp.pp_list pp_exemplar) fmt v.Metrics_types.exemplars;
+    Pbrt.Pp.pp_record_field ~first:false "flags" Pbrt.Pp.pp_int32 fmt v.Metrics_types.flags;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_histogram fmt (v:Metrics_types.histogram) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "data_points" (Pbrt.Pp.pp_list pp_histogram_data_point) fmt v.Metrics_types.data_points;
+    Pbrt.Pp.pp_record_field ~first:false "aggregation_temporality" pp_aggregation_temporality fmt v.Metrics_types.aggregation_temporality;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_exponential_histogram_data_point_buckets fmt (v:Metrics_types.exponential_histogram_data_point_buckets) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "offset" Pbrt.Pp.pp_int32 fmt v.Metrics_types.offset;
+    Pbrt.Pp.pp_record_field ~first:false "bucket_counts" (Pbrt.Pp.pp_list Pbrt.Pp.pp_int64) fmt v.Metrics_types.bucket_counts;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_exponential_histogram_data_point fmt (v:Metrics_types.exponential_histogram_data_point) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "attributes" (Pbrt.Pp.pp_list Common_pp.pp_key_value) fmt v.Metrics_types.attributes;
+    Pbrt.Pp.pp_record_field ~first:false "start_time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Metrics_types.start_time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Metrics_types.time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "count" Pbrt.Pp.pp_int64 fmt v.Metrics_types.count;
+    Pbrt.Pp.pp_record_field ~first:false "sum" Pbrt.Pp.pp_float fmt v.Metrics_types.sum;
+    Pbrt.Pp.pp_record_field ~first:false "scale" Pbrt.Pp.pp_int32 fmt v.Metrics_types.scale;
+    Pbrt.Pp.pp_record_field ~first:false "zero_count" Pbrt.Pp.pp_int64 fmt v.Metrics_types.zero_count;
+    Pbrt.Pp.pp_record_field ~first:false "positive" (Pbrt.Pp.pp_option pp_exponential_histogram_data_point_buckets) fmt v.Metrics_types.positive;
+    Pbrt.Pp.pp_record_field ~first:false "negative" (Pbrt.Pp.pp_option pp_exponential_histogram_data_point_buckets) fmt v.Metrics_types.negative;
+    Pbrt.Pp.pp_record_field ~first:false "flags" Pbrt.Pp.pp_int32 fmt v.Metrics_types.flags;
+    Pbrt.Pp.pp_record_field ~first:false "exemplars" (Pbrt.Pp.pp_list pp_exemplar) fmt v.Metrics_types.exemplars;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_exponential_histogram fmt (v:Metrics_types.exponential_histogram) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "data_points" (Pbrt.Pp.pp_list pp_exponential_histogram_data_point) fmt v.Metrics_types.data_points;
+    Pbrt.Pp.pp_record_field ~first:false "aggregation_temporality" pp_aggregation_temporality fmt v.Metrics_types.aggregation_temporality;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_summary_data_point_value_at_quantile fmt (v:Metrics_types.summary_data_point_value_at_quantile) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "quantile" Pbrt.Pp.pp_float fmt v.Metrics_types.quantile;
+    Pbrt.Pp.pp_record_field ~first:false "value" Pbrt.Pp.pp_float fmt v.Metrics_types.value;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_summary_data_point fmt (v:Metrics_types.summary_data_point) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "attributes" (Pbrt.Pp.pp_list Common_pp.pp_key_value) fmt v.Metrics_types.attributes;
+    Pbrt.Pp.pp_record_field ~first:false "start_time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Metrics_types.start_time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Metrics_types.time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "count" Pbrt.Pp.pp_int64 fmt v.Metrics_types.count;
+    Pbrt.Pp.pp_record_field ~first:false "sum" Pbrt.Pp.pp_float fmt v.Metrics_types.sum;
+    Pbrt.Pp.pp_record_field ~first:false "quantile_values" (Pbrt.Pp.pp_list pp_summary_data_point_value_at_quantile) fmt v.Metrics_types.quantile_values;
+    Pbrt.Pp.pp_record_field ~first:false "flags" Pbrt.Pp.pp_int32 fmt v.Metrics_types.flags;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_summary fmt (v:Metrics_types.summary) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "data_points" (Pbrt.Pp.pp_list pp_summary_data_point) fmt v.Metrics_types.data_points;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_metric_data fmt (v:Metrics_types.metric_data) =
+  match v with
+  | Metrics_types.Gauge x -> Format.fprintf fmt "@[<hv2>Gauge(@,%a)@]" pp_gauge x
+  | Metrics_types.Sum x -> Format.fprintf fmt "@[<hv2>Sum(@,%a)@]" pp_sum x
+  | Metrics_types.Histogram x -> Format.fprintf fmt "@[<hv2>Histogram(@,%a)@]" pp_histogram x
+  | Metrics_types.Exponential_histogram x -> Format.fprintf fmt "@[<hv2>Exponential_histogram(@,%a)@]" pp_exponential_histogram x
+  | Metrics_types.Summary x -> Format.fprintf fmt "@[<hv2>Summary(@,%a)@]" pp_summary x
+
+and pp_metric fmt (v:Metrics_types.metric) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "name" Pbrt.Pp.pp_string fmt v.Metrics_types.name;
+    Pbrt.Pp.pp_record_field ~first:false "description" Pbrt.Pp.pp_string fmt v.Metrics_types.description;
+    Pbrt.Pp.pp_record_field ~first:false "unit_" Pbrt.Pp.pp_string fmt v.Metrics_types.unit_;
+    Pbrt.Pp.pp_record_field ~first:false "data" pp_metric_data fmt v.Metrics_types.data;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_instrumentation_library_metrics fmt (v:Metrics_types.instrumentation_library_metrics) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "instrumentation_library" (Pbrt.Pp.pp_option Common_pp.pp_instrumentation_library) fmt v.Metrics_types.instrumentation_library;
+    Pbrt.Pp.pp_record_field ~first:false "metrics" (Pbrt.Pp.pp_list pp_metric) fmt v.Metrics_types.metrics;
+    Pbrt.Pp.pp_record_field ~first:false "schema_url" Pbrt.Pp.pp_string fmt v.Metrics_types.schema_url;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_resource_metrics fmt (v:Metrics_types.resource_metrics) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "resource" (Pbrt.Pp.pp_option Resource_pp.pp_resource) fmt v.Metrics_types.resource;
+    Pbrt.Pp.pp_record_field ~first:false "instrumentation_library_metrics" (Pbrt.Pp.pp_list pp_instrumentation_library_metrics) fmt v.Metrics_types.instrumentation_library_metrics;
+    Pbrt.Pp.pp_record_field ~first:false "schema_url" Pbrt.Pp.pp_string fmt v.Metrics_types.schema_url;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_metrics_data fmt (v:Metrics_types.metrics_data) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "resource_metrics" (Pbrt.Pp.pp_list pp_resource_metrics) fmt v.Metrics_types.resource_metrics;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_data_point_flags fmt (v:Metrics_types.data_point_flags) =
+  match v with
+  | Metrics_types.Flag_none -> Format.fprintf fmt "Flag_none"
+  | Metrics_types.Flag_no_recorded_value -> Format.fprintf fmt "Flag_no_recorded_value"

--- a/src/metrics_pp.mli
+++ b/src/metrics_pp.mli
@@ -1,0 +1,67 @@
+(** metrics.proto Pretty Printing *)
+
+
+(** {2 Formatters} *)
+
+val pp_exemplar_value : Format.formatter -> Metrics_types.exemplar_value -> unit 
+(** [pp_exemplar_value v] formats v *)
+
+val pp_exemplar : Format.formatter -> Metrics_types.exemplar -> unit 
+(** [pp_exemplar v] formats v *)
+
+val pp_number_data_point_value : Format.formatter -> Metrics_types.number_data_point_value -> unit 
+(** [pp_number_data_point_value v] formats v *)
+
+val pp_number_data_point : Format.formatter -> Metrics_types.number_data_point -> unit 
+(** [pp_number_data_point v] formats v *)
+
+val pp_gauge : Format.formatter -> Metrics_types.gauge -> unit 
+(** [pp_gauge v] formats v *)
+
+val pp_aggregation_temporality : Format.formatter -> Metrics_types.aggregation_temporality -> unit 
+(** [pp_aggregation_temporality v] formats v *)
+
+val pp_sum : Format.formatter -> Metrics_types.sum -> unit 
+(** [pp_sum v] formats v *)
+
+val pp_histogram_data_point : Format.formatter -> Metrics_types.histogram_data_point -> unit 
+(** [pp_histogram_data_point v] formats v *)
+
+val pp_histogram : Format.formatter -> Metrics_types.histogram -> unit 
+(** [pp_histogram v] formats v *)
+
+val pp_exponential_histogram_data_point_buckets : Format.formatter -> Metrics_types.exponential_histogram_data_point_buckets -> unit 
+(** [pp_exponential_histogram_data_point_buckets v] formats v *)
+
+val pp_exponential_histogram_data_point : Format.formatter -> Metrics_types.exponential_histogram_data_point -> unit 
+(** [pp_exponential_histogram_data_point v] formats v *)
+
+val pp_exponential_histogram : Format.formatter -> Metrics_types.exponential_histogram -> unit 
+(** [pp_exponential_histogram v] formats v *)
+
+val pp_summary_data_point_value_at_quantile : Format.formatter -> Metrics_types.summary_data_point_value_at_quantile -> unit 
+(** [pp_summary_data_point_value_at_quantile v] formats v *)
+
+val pp_summary_data_point : Format.formatter -> Metrics_types.summary_data_point -> unit 
+(** [pp_summary_data_point v] formats v *)
+
+val pp_summary : Format.formatter -> Metrics_types.summary -> unit 
+(** [pp_summary v] formats v *)
+
+val pp_metric_data : Format.formatter -> Metrics_types.metric_data -> unit 
+(** [pp_metric_data v] formats v *)
+
+val pp_metric : Format.formatter -> Metrics_types.metric -> unit 
+(** [pp_metric v] formats v *)
+
+val pp_instrumentation_library_metrics : Format.formatter -> Metrics_types.instrumentation_library_metrics -> unit 
+(** [pp_instrumentation_library_metrics v] formats v *)
+
+val pp_resource_metrics : Format.formatter -> Metrics_types.resource_metrics -> unit 
+(** [pp_resource_metrics v] formats v *)
+
+val pp_metrics_data : Format.formatter -> Metrics_types.metrics_data -> unit 
+(** [pp_metrics_data v] formats v *)
+
+val pp_data_point_flags : Format.formatter -> Metrics_types.data_point_flags -> unit 
+(** [pp_data_point_flags v] formats v *)

--- a/src/metrics_service_pb.ml
+++ b/src/metrics_service_pb.ml
@@ -1,0 +1,36 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type export_metrics_service_request_mutable = {
+  mutable resource_metrics : Metrics_types.resource_metrics list;
+}
+
+let default_export_metrics_service_request_mutable () : export_metrics_service_request_mutable = {
+  resource_metrics = [];
+}
+
+
+let rec decode_export_metrics_service_request d =
+  let v = default_export_metrics_service_request_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.resource_metrics <- List.rev v.resource_metrics;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.resource_metrics <- (Metrics_pb.decode_resource_metrics (Pbrt.Decoder.nested d)) :: v.resource_metrics;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(export_metrics_service_request), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Metrics_service_types.resource_metrics = v.resource_metrics;
+  } : Metrics_service_types.export_metrics_service_request)
+
+let rec encode_export_metrics_service_request (v:Metrics_service_types.export_metrics_service_request) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Metrics_pb.encode_resource_metrics x) encoder;
+  ) v.Metrics_service_types.resource_metrics;
+  ()

--- a/src/metrics_service_pb.mli
+++ b/src/metrics_service_pb.mli
@@ -1,0 +1,13 @@
+(** metrics_service.proto Binary Encoding *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_export_metrics_service_request : Metrics_service_types.export_metrics_service_request -> Pbrt.Encoder.t -> unit
+(** [encode_export_metrics_service_request v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_export_metrics_service_request : Pbrt.Decoder.t -> Metrics_service_types.export_metrics_service_request
+(** [decode_export_metrics_service_request decoder] decodes a [export_metrics_service_request] value from [decoder] *)

--- a/src/metrics_service_pp.ml
+++ b/src/metrics_service_pp.ml
@@ -1,0 +1,7 @@
+[@@@ocaml.warning "-27-30-39"]
+
+let rec pp_export_metrics_service_request fmt (v:Metrics_service_types.export_metrics_service_request) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "resource_metrics" (Pbrt.Pp.pp_list Metrics_pp.pp_resource_metrics) fmt v.Metrics_service_types.resource_metrics;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()

--- a/src/metrics_service_pp.mli
+++ b/src/metrics_service_pp.mli
@@ -1,0 +1,7 @@
+(** metrics_service.proto Pretty Printing *)
+
+
+(** {2 Formatters} *)
+
+val pp_export_metrics_service_request : Format.formatter -> Metrics_service_types.export_metrics_service_request -> unit 
+(** [pp_export_metrics_service_request v] formats v *)

--- a/src/metrics_service_types.ml
+++ b/src/metrics_service_types.ml
@@ -1,0 +1,12 @@
+[@@@ocaml.warning "-27-30-39"]
+
+
+type export_metrics_service_request = {
+  resource_metrics : Metrics_types.resource_metrics list;
+}
+
+let rec default_export_metrics_service_request 
+  ?resource_metrics:((resource_metrics:Metrics_types.resource_metrics list) = [])
+  () : export_metrics_service_request  = {
+  resource_metrics;
+}

--- a/src/metrics_service_types.mli
+++ b/src/metrics_service_types.mli
@@ -1,0 +1,18 @@
+(** metrics_service.proto Types *)
+
+
+
+(** {2 Types} *)
+
+type export_metrics_service_request = {
+  resource_metrics : Metrics_types.resource_metrics list;
+}
+
+
+(** {2 Default values} *)
+
+val default_export_metrics_service_request : 
+  ?resource_metrics:Metrics_types.resource_metrics list ->
+  unit ->
+  export_metrics_service_request
+(** [default_export_metrics_service_request ()] is the default value for type [export_metrics_service_request] *)

--- a/src/metrics_types.ml
+++ b/src/metrics_types.ml
@@ -1,0 +1,334 @@
+[@@@ocaml.warning "-27-30-39"]
+
+
+type exemplar_value =
+  | As_double of float
+  | As_int of int64
+
+and exemplar = {
+  filtered_attributes : Common_types.key_value list;
+  time_unix_nano : int64;
+  value : exemplar_value;
+  span_id : bytes;
+  trace_id : bytes;
+}
+
+type number_data_point_value =
+  | As_double of float
+  | As_int of int64
+
+and number_data_point = {
+  attributes : Common_types.key_value list;
+  start_time_unix_nano : int64;
+  time_unix_nano : int64;
+  value : number_data_point_value;
+  exemplars : exemplar list;
+  flags : int32;
+}
+
+type gauge = {
+  data_points : number_data_point list;
+}
+
+type aggregation_temporality =
+  | Aggregation_temporality_unspecified 
+  | Aggregation_temporality_delta 
+  | Aggregation_temporality_cumulative 
+
+type sum = {
+  data_points : number_data_point list;
+  aggregation_temporality : aggregation_temporality;
+  is_monotonic : bool;
+}
+
+type histogram_data_point = {
+  attributes : Common_types.key_value list;
+  start_time_unix_nano : int64;
+  time_unix_nano : int64;
+  count : int64;
+  sum : float;
+  bucket_counts : int64 list;
+  explicit_bounds : float list;
+  exemplars : exemplar list;
+  flags : int32;
+}
+
+type histogram = {
+  data_points : histogram_data_point list;
+  aggregation_temporality : aggregation_temporality;
+}
+
+type exponential_histogram_data_point_buckets = {
+  offset : int32;
+  bucket_counts : int64 list;
+}
+
+type exponential_histogram_data_point = {
+  attributes : Common_types.key_value list;
+  start_time_unix_nano : int64;
+  time_unix_nano : int64;
+  count : int64;
+  sum : float;
+  scale : int32;
+  zero_count : int64;
+  positive : exponential_histogram_data_point_buckets option;
+  negative : exponential_histogram_data_point_buckets option;
+  flags : int32;
+  exemplars : exemplar list;
+}
+
+type exponential_histogram = {
+  data_points : exponential_histogram_data_point list;
+  aggregation_temporality : aggregation_temporality;
+}
+
+type summary_data_point_value_at_quantile = {
+  quantile : float;
+  value : float;
+}
+
+type summary_data_point = {
+  attributes : Common_types.key_value list;
+  start_time_unix_nano : int64;
+  time_unix_nano : int64;
+  count : int64;
+  sum : float;
+  quantile_values : summary_data_point_value_at_quantile list;
+  flags : int32;
+}
+
+type summary = {
+  data_points : summary_data_point list;
+}
+
+type metric_data =
+  | Gauge of gauge
+  | Sum of sum
+  | Histogram of histogram
+  | Exponential_histogram of exponential_histogram
+  | Summary of summary
+
+and metric = {
+  name : string;
+  description : string;
+  unit_ : string;
+  data : metric_data;
+}
+
+type instrumentation_library_metrics = {
+  instrumentation_library : Common_types.instrumentation_library option;
+  metrics : metric list;
+  schema_url : string;
+}
+
+type resource_metrics = {
+  resource : Resource_types.resource option;
+  instrumentation_library_metrics : instrumentation_library_metrics list;
+  schema_url : string;
+}
+
+type metrics_data = {
+  resource_metrics : resource_metrics list;
+}
+
+type data_point_flags =
+  | Flag_none 
+  | Flag_no_recorded_value 
+
+let rec default_exemplar_value () : exemplar_value = As_double (0.)
+
+and default_exemplar 
+  ?filtered_attributes:((filtered_attributes:Common_types.key_value list) = [])
+  ?time_unix_nano:((time_unix_nano:int64) = 0L)
+  ?value:((value:exemplar_value) = As_double (0.))
+  ?span_id:((span_id:bytes) = Bytes.create 0)
+  ?trace_id:((trace_id:bytes) = Bytes.create 0)
+  () : exemplar  = {
+  filtered_attributes;
+  time_unix_nano;
+  value;
+  span_id;
+  trace_id;
+}
+
+let rec default_number_data_point_value () : number_data_point_value = As_double (0.)
+
+and default_number_data_point 
+  ?attributes:((attributes:Common_types.key_value list) = [])
+  ?start_time_unix_nano:((start_time_unix_nano:int64) = 0L)
+  ?time_unix_nano:((time_unix_nano:int64) = 0L)
+  ?value:((value:number_data_point_value) = As_double (0.))
+  ?exemplars:((exemplars:exemplar list) = [])
+  ?flags:((flags:int32) = 0l)
+  () : number_data_point  = {
+  attributes;
+  start_time_unix_nano;
+  time_unix_nano;
+  value;
+  exemplars;
+  flags;
+}
+
+let rec default_gauge 
+  ?data_points:((data_points:number_data_point list) = [])
+  () : gauge  = {
+  data_points;
+}
+
+let rec default_aggregation_temporality () = (Aggregation_temporality_unspecified:aggregation_temporality)
+
+let rec default_sum 
+  ?data_points:((data_points:number_data_point list) = [])
+  ?aggregation_temporality:((aggregation_temporality:aggregation_temporality) = default_aggregation_temporality ())
+  ?is_monotonic:((is_monotonic:bool) = false)
+  () : sum  = {
+  data_points;
+  aggregation_temporality;
+  is_monotonic;
+}
+
+let rec default_histogram_data_point 
+  ?attributes:((attributes:Common_types.key_value list) = [])
+  ?start_time_unix_nano:((start_time_unix_nano:int64) = 0L)
+  ?time_unix_nano:((time_unix_nano:int64) = 0L)
+  ?count:((count:int64) = 0L)
+  ?sum:((sum:float) = 0.)
+  ?bucket_counts:((bucket_counts:int64 list) = [])
+  ?explicit_bounds:((explicit_bounds:float list) = [])
+  ?exemplars:((exemplars:exemplar list) = [])
+  ?flags:((flags:int32) = 0l)
+  () : histogram_data_point  = {
+  attributes;
+  start_time_unix_nano;
+  time_unix_nano;
+  count;
+  sum;
+  bucket_counts;
+  explicit_bounds;
+  exemplars;
+  flags;
+}
+
+let rec default_histogram 
+  ?data_points:((data_points:histogram_data_point list) = [])
+  ?aggregation_temporality:((aggregation_temporality:aggregation_temporality) = default_aggregation_temporality ())
+  () : histogram  = {
+  data_points;
+  aggregation_temporality;
+}
+
+let rec default_exponential_histogram_data_point_buckets 
+  ?offset:((offset:int32) = 0l)
+  ?bucket_counts:((bucket_counts:int64 list) = [])
+  () : exponential_histogram_data_point_buckets  = {
+  offset;
+  bucket_counts;
+}
+
+let rec default_exponential_histogram_data_point 
+  ?attributes:((attributes:Common_types.key_value list) = [])
+  ?start_time_unix_nano:((start_time_unix_nano:int64) = 0L)
+  ?time_unix_nano:((time_unix_nano:int64) = 0L)
+  ?count:((count:int64) = 0L)
+  ?sum:((sum:float) = 0.)
+  ?scale:((scale:int32) = 0l)
+  ?zero_count:((zero_count:int64) = 0L)
+  ?positive:((positive:exponential_histogram_data_point_buckets option) = None)
+  ?negative:((negative:exponential_histogram_data_point_buckets option) = None)
+  ?flags:((flags:int32) = 0l)
+  ?exemplars:((exemplars:exemplar list) = [])
+  () : exponential_histogram_data_point  = {
+  attributes;
+  start_time_unix_nano;
+  time_unix_nano;
+  count;
+  sum;
+  scale;
+  zero_count;
+  positive;
+  negative;
+  flags;
+  exemplars;
+}
+
+let rec default_exponential_histogram 
+  ?data_points:((data_points:exponential_histogram_data_point list) = [])
+  ?aggregation_temporality:((aggregation_temporality:aggregation_temporality) = default_aggregation_temporality ())
+  () : exponential_histogram  = {
+  data_points;
+  aggregation_temporality;
+}
+
+let rec default_summary_data_point_value_at_quantile 
+  ?quantile:((quantile:float) = 0.)
+  ?value:((value:float) = 0.)
+  () : summary_data_point_value_at_quantile  = {
+  quantile;
+  value;
+}
+
+let rec default_summary_data_point 
+  ?attributes:((attributes:Common_types.key_value list) = [])
+  ?start_time_unix_nano:((start_time_unix_nano:int64) = 0L)
+  ?time_unix_nano:((time_unix_nano:int64) = 0L)
+  ?count:((count:int64) = 0L)
+  ?sum:((sum:float) = 0.)
+  ?quantile_values:((quantile_values:summary_data_point_value_at_quantile list) = [])
+  ?flags:((flags:int32) = 0l)
+  () : summary_data_point  = {
+  attributes;
+  start_time_unix_nano;
+  time_unix_nano;
+  count;
+  sum;
+  quantile_values;
+  flags;
+}
+
+let rec default_summary 
+  ?data_points:((data_points:summary_data_point list) = [])
+  () : summary  = {
+  data_points;
+}
+
+let rec default_metric_data () : metric_data = Gauge (default_gauge ())
+
+and default_metric 
+  ?name:((name:string) = "")
+  ?description:((description:string) = "")
+  ?unit_:((unit_:string) = "")
+  ?data:((data:metric_data) = Gauge (default_gauge ()))
+  () : metric  = {
+  name;
+  description;
+  unit_;
+  data;
+}
+
+let rec default_instrumentation_library_metrics 
+  ?instrumentation_library:((instrumentation_library:Common_types.instrumentation_library option) = None)
+  ?metrics:((metrics:metric list) = [])
+  ?schema_url:((schema_url:string) = "")
+  () : instrumentation_library_metrics  = {
+  instrumentation_library;
+  metrics;
+  schema_url;
+}
+
+let rec default_resource_metrics 
+  ?resource:((resource:Resource_types.resource option) = None)
+  ?instrumentation_library_metrics:((instrumentation_library_metrics:instrumentation_library_metrics list) = [])
+  ?schema_url:((schema_url:string) = "")
+  () : resource_metrics  = {
+  resource;
+  instrumentation_library_metrics;
+  schema_url;
+}
+
+let rec default_metrics_data 
+  ?resource_metrics:((resource_metrics:resource_metrics list) = [])
+  () : metrics_data  = {
+  resource_metrics;
+}
+
+let rec default_data_point_flags () = (Flag_none:data_point_flags)

--- a/src/metrics_types.mli
+++ b/src/metrics_types.mli
@@ -1,0 +1,299 @@
+(** metrics.proto Types *)
+
+
+
+(** {2 Types} *)
+
+type exemplar_value =
+  | As_double of float
+  | As_int of int64
+
+and exemplar = {
+  filtered_attributes : Common_types.key_value list;
+  time_unix_nano : int64;
+  value : exemplar_value;
+  span_id : bytes;
+  trace_id : bytes;
+}
+
+type number_data_point_value =
+  | As_double of float
+  | As_int of int64
+
+and number_data_point = {
+  attributes : Common_types.key_value list;
+  start_time_unix_nano : int64;
+  time_unix_nano : int64;
+  value : number_data_point_value;
+  exemplars : exemplar list;
+  flags : int32;
+}
+
+type gauge = {
+  data_points : number_data_point list;
+}
+
+type aggregation_temporality =
+  | Aggregation_temporality_unspecified 
+  | Aggregation_temporality_delta 
+  | Aggregation_temporality_cumulative 
+
+type sum = {
+  data_points : number_data_point list;
+  aggregation_temporality : aggregation_temporality;
+  is_monotonic : bool;
+}
+
+type histogram_data_point = {
+  attributes : Common_types.key_value list;
+  start_time_unix_nano : int64;
+  time_unix_nano : int64;
+  count : int64;
+  sum : float;
+  bucket_counts : int64 list;
+  explicit_bounds : float list;
+  exemplars : exemplar list;
+  flags : int32;
+}
+
+type histogram = {
+  data_points : histogram_data_point list;
+  aggregation_temporality : aggregation_temporality;
+}
+
+type exponential_histogram_data_point_buckets = {
+  offset : int32;
+  bucket_counts : int64 list;
+}
+
+type exponential_histogram_data_point = {
+  attributes : Common_types.key_value list;
+  start_time_unix_nano : int64;
+  time_unix_nano : int64;
+  count : int64;
+  sum : float;
+  scale : int32;
+  zero_count : int64;
+  positive : exponential_histogram_data_point_buckets option;
+  negative : exponential_histogram_data_point_buckets option;
+  flags : int32;
+  exemplars : exemplar list;
+}
+
+type exponential_histogram = {
+  data_points : exponential_histogram_data_point list;
+  aggregation_temporality : aggregation_temporality;
+}
+
+type summary_data_point_value_at_quantile = {
+  quantile : float;
+  value : float;
+}
+
+type summary_data_point = {
+  attributes : Common_types.key_value list;
+  start_time_unix_nano : int64;
+  time_unix_nano : int64;
+  count : int64;
+  sum : float;
+  quantile_values : summary_data_point_value_at_quantile list;
+  flags : int32;
+}
+
+type summary = {
+  data_points : summary_data_point list;
+}
+
+type metric_data =
+  | Gauge of gauge
+  | Sum of sum
+  | Histogram of histogram
+  | Exponential_histogram of exponential_histogram
+  | Summary of summary
+
+and metric = {
+  name : string;
+  description : string;
+  unit_ : string;
+  data : metric_data;
+}
+
+type instrumentation_library_metrics = {
+  instrumentation_library : Common_types.instrumentation_library option;
+  metrics : metric list;
+  schema_url : string;
+}
+
+type resource_metrics = {
+  resource : Resource_types.resource option;
+  instrumentation_library_metrics : instrumentation_library_metrics list;
+  schema_url : string;
+}
+
+type metrics_data = {
+  resource_metrics : resource_metrics list;
+}
+
+type data_point_flags =
+  | Flag_none 
+  | Flag_no_recorded_value 
+
+
+(** {2 Default values} *)
+
+val default_exemplar_value : unit -> exemplar_value
+(** [default_exemplar_value ()] is the default value for type [exemplar_value] *)
+
+val default_exemplar : 
+  ?filtered_attributes:Common_types.key_value list ->
+  ?time_unix_nano:int64 ->
+  ?value:exemplar_value ->
+  ?span_id:bytes ->
+  ?trace_id:bytes ->
+  unit ->
+  exemplar
+(** [default_exemplar ()] is the default value for type [exemplar] *)
+
+val default_number_data_point_value : unit -> number_data_point_value
+(** [default_number_data_point_value ()] is the default value for type [number_data_point_value] *)
+
+val default_number_data_point : 
+  ?attributes:Common_types.key_value list ->
+  ?start_time_unix_nano:int64 ->
+  ?time_unix_nano:int64 ->
+  ?value:number_data_point_value ->
+  ?exemplars:exemplar list ->
+  ?flags:int32 ->
+  unit ->
+  number_data_point
+(** [default_number_data_point ()] is the default value for type [number_data_point] *)
+
+val default_gauge : 
+  ?data_points:number_data_point list ->
+  unit ->
+  gauge
+(** [default_gauge ()] is the default value for type [gauge] *)
+
+val default_aggregation_temporality : unit -> aggregation_temporality
+(** [default_aggregation_temporality ()] is the default value for type [aggregation_temporality] *)
+
+val default_sum : 
+  ?data_points:number_data_point list ->
+  ?aggregation_temporality:aggregation_temporality ->
+  ?is_monotonic:bool ->
+  unit ->
+  sum
+(** [default_sum ()] is the default value for type [sum] *)
+
+val default_histogram_data_point : 
+  ?attributes:Common_types.key_value list ->
+  ?start_time_unix_nano:int64 ->
+  ?time_unix_nano:int64 ->
+  ?count:int64 ->
+  ?sum:float ->
+  ?bucket_counts:int64 list ->
+  ?explicit_bounds:float list ->
+  ?exemplars:exemplar list ->
+  ?flags:int32 ->
+  unit ->
+  histogram_data_point
+(** [default_histogram_data_point ()] is the default value for type [histogram_data_point] *)
+
+val default_histogram : 
+  ?data_points:histogram_data_point list ->
+  ?aggregation_temporality:aggregation_temporality ->
+  unit ->
+  histogram
+(** [default_histogram ()] is the default value for type [histogram] *)
+
+val default_exponential_histogram_data_point_buckets : 
+  ?offset:int32 ->
+  ?bucket_counts:int64 list ->
+  unit ->
+  exponential_histogram_data_point_buckets
+(** [default_exponential_histogram_data_point_buckets ()] is the default value for type [exponential_histogram_data_point_buckets] *)
+
+val default_exponential_histogram_data_point : 
+  ?attributes:Common_types.key_value list ->
+  ?start_time_unix_nano:int64 ->
+  ?time_unix_nano:int64 ->
+  ?count:int64 ->
+  ?sum:float ->
+  ?scale:int32 ->
+  ?zero_count:int64 ->
+  ?positive:exponential_histogram_data_point_buckets option ->
+  ?negative:exponential_histogram_data_point_buckets option ->
+  ?flags:int32 ->
+  ?exemplars:exemplar list ->
+  unit ->
+  exponential_histogram_data_point
+(** [default_exponential_histogram_data_point ()] is the default value for type [exponential_histogram_data_point] *)
+
+val default_exponential_histogram : 
+  ?data_points:exponential_histogram_data_point list ->
+  ?aggregation_temporality:aggregation_temporality ->
+  unit ->
+  exponential_histogram
+(** [default_exponential_histogram ()] is the default value for type [exponential_histogram] *)
+
+val default_summary_data_point_value_at_quantile : 
+  ?quantile:float ->
+  ?value:float ->
+  unit ->
+  summary_data_point_value_at_quantile
+(** [default_summary_data_point_value_at_quantile ()] is the default value for type [summary_data_point_value_at_quantile] *)
+
+val default_summary_data_point : 
+  ?attributes:Common_types.key_value list ->
+  ?start_time_unix_nano:int64 ->
+  ?time_unix_nano:int64 ->
+  ?count:int64 ->
+  ?sum:float ->
+  ?quantile_values:summary_data_point_value_at_quantile list ->
+  ?flags:int32 ->
+  unit ->
+  summary_data_point
+(** [default_summary_data_point ()] is the default value for type [summary_data_point] *)
+
+val default_summary : 
+  ?data_points:summary_data_point list ->
+  unit ->
+  summary
+(** [default_summary ()] is the default value for type [summary] *)
+
+val default_metric_data : unit -> metric_data
+(** [default_metric_data ()] is the default value for type [metric_data] *)
+
+val default_metric : 
+  ?name:string ->
+  ?description:string ->
+  ?unit_:string ->
+  ?data:metric_data ->
+  unit ->
+  metric
+(** [default_metric ()] is the default value for type [metric] *)
+
+val default_instrumentation_library_metrics : 
+  ?instrumentation_library:Common_types.instrumentation_library option ->
+  ?metrics:metric list ->
+  ?schema_url:string ->
+  unit ->
+  instrumentation_library_metrics
+(** [default_instrumentation_library_metrics ()] is the default value for type [instrumentation_library_metrics] *)
+
+val default_resource_metrics : 
+  ?resource:Resource_types.resource option ->
+  ?instrumentation_library_metrics:instrumentation_library_metrics list ->
+  ?schema_url:string ->
+  unit ->
+  resource_metrics
+(** [default_resource_metrics ()] is the default value for type [resource_metrics] *)
+
+val default_metrics_data : 
+  ?resource_metrics:resource_metrics list ->
+  unit ->
+  metrics_data
+(** [default_metrics_data ()] is the default value for type [metrics_data] *)
+
+val default_data_point_flags : unit -> data_point_flags
+(** [default_data_point_flags ()] is the default value for type [data_point_flags] *)

--- a/src/resource_pb.ml
+++ b/src/resource_pb.ml
@@ -1,0 +1,46 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type resource_mutable = {
+  mutable attributes : Common_types.key_value list;
+  mutable dropped_attributes_count : int32;
+}
+
+let default_resource_mutable () : resource_mutable = {
+  attributes = [];
+  dropped_attributes_count = 0l;
+}
+
+
+let rec decode_resource d =
+  let v = default_resource_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.attributes <- List.rev v.attributes;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.attributes <- (Common_pb.decode_key_value (Pbrt.Decoder.nested d)) :: v.attributes;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(resource), field(1)" pk
+    | Some (2, Pbrt.Varint) -> begin
+      v.dropped_attributes_count <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(resource), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Resource_types.attributes = v.attributes;
+    Resource_types.dropped_attributes_count = v.dropped_attributes_count;
+  } : Resource_types.resource)
+
+let rec encode_resource (v:Resource_types.resource) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_key_value x) encoder;
+  ) v.Resource_types.attributes;
+  Pbrt.Encoder.key (2, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Resource_types.dropped_attributes_count encoder;
+  ()

--- a/src/resource_pb.mli
+++ b/src/resource_pb.mli
@@ -1,0 +1,13 @@
+(** resource.proto Binary Encoding *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_resource : Resource_types.resource -> Pbrt.Encoder.t -> unit
+(** [encode_resource v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_resource : Pbrt.Decoder.t -> Resource_types.resource
+(** [decode_resource decoder] decodes a [resource] value from [decoder] *)

--- a/src/resource_pp.ml
+++ b/src/resource_pp.ml
@@ -1,0 +1,8 @@
+[@@@ocaml.warning "-27-30-39"]
+
+let rec pp_resource fmt (v:Resource_types.resource) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "attributes" (Pbrt.Pp.pp_list Common_pp.pp_key_value) fmt v.Resource_types.attributes;
+    Pbrt.Pp.pp_record_field ~first:false "dropped_attributes_count" Pbrt.Pp.pp_int32 fmt v.Resource_types.dropped_attributes_count;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()

--- a/src/resource_pp.mli
+++ b/src/resource_pp.mli
@@ -1,0 +1,7 @@
+(** resource.proto Pretty Printing *)
+
+
+(** {2 Formatters} *)
+
+val pp_resource : Format.formatter -> Resource_types.resource -> unit 
+(** [pp_resource v] formats v *)

--- a/src/resource_types.ml
+++ b/src/resource_types.ml
@@ -1,0 +1,15 @@
+[@@@ocaml.warning "-27-30-39"]
+
+
+type resource = {
+  attributes : Common_types.key_value list;
+  dropped_attributes_count : int32;
+}
+
+let rec default_resource 
+  ?attributes:((attributes:Common_types.key_value list) = [])
+  ?dropped_attributes_count:((dropped_attributes_count:int32) = 0l)
+  () : resource  = {
+  attributes;
+  dropped_attributes_count;
+}

--- a/src/resource_types.mli
+++ b/src/resource_types.mli
@@ -1,0 +1,20 @@
+(** resource.proto Types *)
+
+
+
+(** {2 Types} *)
+
+type resource = {
+  attributes : Common_types.key_value list;
+  dropped_attributes_count : int32;
+}
+
+
+(** {2 Default values} *)
+
+val default_resource : 
+  ?attributes:Common_types.key_value list ->
+  ?dropped_attributes_count:int32 ->
+  unit ->
+  resource
+(** [default_resource ()] is the default value for type [resource] *)

--- a/src/status_pb.ml
+++ b/src/status_pb.ml
@@ -1,0 +1,56 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type status_mutable = {
+  mutable code : int32;
+  mutable message : bytes;
+  mutable details : bytes list;
+}
+
+let default_status_mutable () : status_mutable = {
+  code = 0l;
+  message = Bytes.create 0;
+  details = [];
+}
+
+
+let rec decode_status d =
+  let v = default_status_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.details <- List.rev v.details;
+    ); continue__ := false
+    | Some (1, Pbrt.Varint) -> begin
+      v.code <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(status), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.message <- Pbrt.Decoder.bytes d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(status), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.details <- (Pbrt.Decoder.bytes d) :: v.details;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(status), field(3)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Status_types.code = v.code;
+    Status_types.message = v.message;
+    Status_types.details = v.details;
+  } : Status_types.status)
+
+let rec encode_status (v:Status_types.status) encoder = 
+  Pbrt.Encoder.key (1, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Status_types.code encoder;
+  Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.bytes v.Status_types.message encoder;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (3, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.bytes x encoder;
+  ) v.Status_types.details;
+  ()

--- a/src/status_pb.mli
+++ b/src/status_pb.mli
@@ -1,0 +1,13 @@
+(** status.proto Binary Encoding *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_status : Status_types.status -> Pbrt.Encoder.t -> unit
+(** [encode_status v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_status : Pbrt.Decoder.t -> Status_types.status
+(** [decode_status decoder] decodes a [status] value from [decoder] *)

--- a/src/status_pp.ml
+++ b/src/status_pp.ml
@@ -1,0 +1,9 @@
+[@@@ocaml.warning "-27-30-39"]
+
+let rec pp_status fmt (v:Status_types.status) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "code" Pbrt.Pp.pp_int32 fmt v.Status_types.code;
+    Pbrt.Pp.pp_record_field ~first:false "message" Pbrt.Pp.pp_bytes fmt v.Status_types.message;
+    Pbrt.Pp.pp_record_field ~first:false "details" (Pbrt.Pp.pp_list Pbrt.Pp.pp_bytes) fmt v.Status_types.details;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()

--- a/src/status_pp.mli
+++ b/src/status_pp.mli
@@ -1,0 +1,7 @@
+(** status.proto Pretty Printing *)
+
+
+(** {2 Formatters} *)
+
+val pp_status : Format.formatter -> Status_types.status -> unit 
+(** [pp_status v] formats v *)

--- a/src/status_types.ml
+++ b/src/status_types.ml
@@ -1,0 +1,18 @@
+[@@@ocaml.warning "-27-30-39"]
+
+
+type status = {
+  code : int32;
+  message : bytes;
+  details : bytes list;
+}
+
+let rec default_status 
+  ?code:((code:int32) = 0l)
+  ?message:((message:bytes) = Bytes.create 0)
+  ?details:((details:bytes list) = [])
+  () : status  = {
+  code;
+  message;
+  details;
+}

--- a/src/status_types.mli
+++ b/src/status_types.mli
@@ -1,0 +1,22 @@
+(** status.proto Types *)
+
+
+
+(** {2 Types} *)
+
+type status = {
+  code : int32;
+  message : bytes;
+  details : bytes list;
+}
+
+
+(** {2 Default values} *)
+
+val default_status : 
+  ?code:int32 ->
+  ?message:bytes ->
+  ?details:bytes list ->
+  unit ->
+  status
+(** [default_status ()] is the default value for type [status] *)

--- a/src/trace_pb.ml
+++ b/src/trace_pb.ml
@@ -1,0 +1,547 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type span_event_mutable = {
+  mutable time_unix_nano : int64;
+  mutable name : string;
+  mutable attributes : Common_types.key_value list;
+  mutable dropped_attributes_count : int32;
+}
+
+let default_span_event_mutable () : span_event_mutable = {
+  time_unix_nano = 0L;
+  name = "";
+  attributes = [];
+  dropped_attributes_count = 0l;
+}
+
+type span_link_mutable = {
+  mutable trace_id : bytes;
+  mutable span_id : bytes;
+  mutable trace_state : string;
+  mutable attributes : Common_types.key_value list;
+  mutable dropped_attributes_count : int32;
+}
+
+let default_span_link_mutable () : span_link_mutable = {
+  trace_id = Bytes.create 0;
+  span_id = Bytes.create 0;
+  trace_state = "";
+  attributes = [];
+  dropped_attributes_count = 0l;
+}
+
+type status_mutable = {
+  mutable message : string;
+  mutable code : Trace_types.status_status_code;
+}
+
+let default_status_mutable () : status_mutable = {
+  message = "";
+  code = Trace_types.default_status_status_code ();
+}
+
+type span_mutable = {
+  mutable trace_id : bytes;
+  mutable span_id : bytes;
+  mutable trace_state : string;
+  mutable parent_span_id : bytes;
+  mutable name : string;
+  mutable kind : Trace_types.span_span_kind;
+  mutable start_time_unix_nano : int64;
+  mutable end_time_unix_nano : int64;
+  mutable attributes : Common_types.key_value list;
+  mutable dropped_attributes_count : int32;
+  mutable events : Trace_types.span_event list;
+  mutable dropped_events_count : int32;
+  mutable links : Trace_types.span_link list;
+  mutable dropped_links_count : int32;
+  mutable status : Trace_types.status option;
+}
+
+let default_span_mutable () : span_mutable = {
+  trace_id = Bytes.create 0;
+  span_id = Bytes.create 0;
+  trace_state = "";
+  parent_span_id = Bytes.create 0;
+  name = "";
+  kind = Trace_types.default_span_span_kind ();
+  start_time_unix_nano = 0L;
+  end_time_unix_nano = 0L;
+  attributes = [];
+  dropped_attributes_count = 0l;
+  events = [];
+  dropped_events_count = 0l;
+  links = [];
+  dropped_links_count = 0l;
+  status = None;
+}
+
+type instrumentation_library_spans_mutable = {
+  mutable instrumentation_library : Common_types.instrumentation_library option;
+  mutable spans : Trace_types.span list;
+  mutable schema_url : string;
+}
+
+let default_instrumentation_library_spans_mutable () : instrumentation_library_spans_mutable = {
+  instrumentation_library = None;
+  spans = [];
+  schema_url = "";
+}
+
+type resource_spans_mutable = {
+  mutable resource : Resource_types.resource option;
+  mutable instrumentation_library_spans : Trace_types.instrumentation_library_spans list;
+  mutable schema_url : string;
+}
+
+let default_resource_spans_mutable () : resource_spans_mutable = {
+  resource = None;
+  instrumentation_library_spans = [];
+  schema_url = "";
+}
+
+type traces_data_mutable = {
+  mutable resource_spans : Trace_types.resource_spans list;
+}
+
+let default_traces_data_mutable () : traces_data_mutable = {
+  resource_spans = [];
+}
+
+
+let rec decode_span_span_kind d = 
+  match Pbrt.Decoder.int_as_varint d with
+  | 0 -> (Trace_types.Span_kind_unspecified:Trace_types.span_span_kind)
+  | 1 -> (Trace_types.Span_kind_internal:Trace_types.span_span_kind)
+  | 2 -> (Trace_types.Span_kind_server:Trace_types.span_span_kind)
+  | 3 -> (Trace_types.Span_kind_client:Trace_types.span_span_kind)
+  | 4 -> (Trace_types.Span_kind_producer:Trace_types.span_span_kind)
+  | 5 -> (Trace_types.Span_kind_consumer:Trace_types.span_span_kind)
+  | _ -> Pbrt.Decoder.malformed_variant "span_span_kind"
+
+let rec decode_span_event d =
+  let v = default_span_event_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.attributes <- List.rev v.attributes;
+    ); continue__ := false
+    | Some (1, Pbrt.Bits64) -> begin
+      v.time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span_event), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.name <- Pbrt.Decoder.string d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span_event), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.attributes <- (Common_pb.decode_key_value (Pbrt.Decoder.nested d)) :: v.attributes;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span_event), field(3)" pk
+    | Some (4, Pbrt.Varint) -> begin
+      v.dropped_attributes_count <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span_event), field(4)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Trace_types.time_unix_nano = v.time_unix_nano;
+    Trace_types.name = v.name;
+    Trace_types.attributes = v.attributes;
+    Trace_types.dropped_attributes_count = v.dropped_attributes_count;
+  } : Trace_types.span_event)
+
+let rec decode_span_link d =
+  let v = default_span_link_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.attributes <- List.rev v.attributes;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.trace_id <- Pbrt.Decoder.bytes d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span_link), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.span_id <- Pbrt.Decoder.bytes d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span_link), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.trace_state <- Pbrt.Decoder.string d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span_link), field(3)" pk
+    | Some (4, Pbrt.Bytes) -> begin
+      v.attributes <- (Common_pb.decode_key_value (Pbrt.Decoder.nested d)) :: v.attributes;
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span_link), field(4)" pk
+    | Some (5, Pbrt.Varint) -> begin
+      v.dropped_attributes_count <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (5, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span_link), field(5)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Trace_types.trace_id = v.trace_id;
+    Trace_types.span_id = v.span_id;
+    Trace_types.trace_state = v.trace_state;
+    Trace_types.attributes = v.attributes;
+    Trace_types.dropped_attributes_count = v.dropped_attributes_count;
+  } : Trace_types.span_link)
+
+let rec decode_status_status_code d = 
+  match Pbrt.Decoder.int_as_varint d with
+  | 0 -> (Trace_types.Status_code_unset:Trace_types.status_status_code)
+  | 1 -> (Trace_types.Status_code_ok:Trace_types.status_status_code)
+  | 2 -> (Trace_types.Status_code_error:Trace_types.status_status_code)
+  | _ -> Pbrt.Decoder.malformed_variant "status_status_code"
+
+let rec decode_status d =
+  let v = default_status_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (2, Pbrt.Bytes) -> begin
+      v.message <- Pbrt.Decoder.string d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(status), field(2)" pk
+    | Some (3, Pbrt.Varint) -> begin
+      v.code <- decode_status_status_code d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(status), field(3)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Trace_types.message = v.message;
+    Trace_types.code = v.code;
+  } : Trace_types.status)
+
+let rec decode_span d =
+  let v = default_span_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.links <- List.rev v.links;
+      v.events <- List.rev v.events;
+      v.attributes <- List.rev v.attributes;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.trace_id <- Pbrt.Decoder.bytes d;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.span_id <- Pbrt.Decoder.bytes d;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.trace_state <- Pbrt.Decoder.string d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(3)" pk
+    | Some (4, Pbrt.Bytes) -> begin
+      v.parent_span_id <- Pbrt.Decoder.bytes d;
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(4)" pk
+    | Some (5, Pbrt.Bytes) -> begin
+      v.name <- Pbrt.Decoder.string d;
+    end
+    | Some (5, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(5)" pk
+    | Some (6, Pbrt.Varint) -> begin
+      v.kind <- decode_span_span_kind d;
+    end
+    | Some (6, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(6)" pk
+    | Some (7, Pbrt.Bits64) -> begin
+      v.start_time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (7, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(7)" pk
+    | Some (8, Pbrt.Bits64) -> begin
+      v.end_time_unix_nano <- Pbrt.Decoder.int64_as_bits64 d;
+    end
+    | Some (8, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(8)" pk
+    | Some (9, Pbrt.Bytes) -> begin
+      v.attributes <- (Common_pb.decode_key_value (Pbrt.Decoder.nested d)) :: v.attributes;
+    end
+    | Some (9, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(9)" pk
+    | Some (10, Pbrt.Varint) -> begin
+      v.dropped_attributes_count <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (10, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(10)" pk
+    | Some (11, Pbrt.Bytes) -> begin
+      v.events <- (decode_span_event (Pbrt.Decoder.nested d)) :: v.events;
+    end
+    | Some (11, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(11)" pk
+    | Some (12, Pbrt.Varint) -> begin
+      v.dropped_events_count <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (12, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(12)" pk
+    | Some (13, Pbrt.Bytes) -> begin
+      v.links <- (decode_span_link (Pbrt.Decoder.nested d)) :: v.links;
+    end
+    | Some (13, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(13)" pk
+    | Some (14, Pbrt.Varint) -> begin
+      v.dropped_links_count <- Pbrt.Decoder.int32_as_varint d;
+    end
+    | Some (14, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(14)" pk
+    | Some (15, Pbrt.Bytes) -> begin
+      v.status <- Some (decode_status (Pbrt.Decoder.nested d));
+    end
+    | Some (15, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(span), field(15)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Trace_types.trace_id = v.trace_id;
+    Trace_types.span_id = v.span_id;
+    Trace_types.trace_state = v.trace_state;
+    Trace_types.parent_span_id = v.parent_span_id;
+    Trace_types.name = v.name;
+    Trace_types.kind = v.kind;
+    Trace_types.start_time_unix_nano = v.start_time_unix_nano;
+    Trace_types.end_time_unix_nano = v.end_time_unix_nano;
+    Trace_types.attributes = v.attributes;
+    Trace_types.dropped_attributes_count = v.dropped_attributes_count;
+    Trace_types.events = v.events;
+    Trace_types.dropped_events_count = v.dropped_events_count;
+    Trace_types.links = v.links;
+    Trace_types.dropped_links_count = v.dropped_links_count;
+    Trace_types.status = v.status;
+  } : Trace_types.span)
+
+let rec decode_instrumentation_library_spans d =
+  let v = default_instrumentation_library_spans_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.spans <- List.rev v.spans;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.instrumentation_library <- Some (Common_pb.decode_instrumentation_library (Pbrt.Decoder.nested d));
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(instrumentation_library_spans), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.spans <- (decode_span (Pbrt.Decoder.nested d)) :: v.spans;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(instrumentation_library_spans), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.schema_url <- Pbrt.Decoder.string d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(instrumentation_library_spans), field(3)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Trace_types.instrumentation_library = v.instrumentation_library;
+    Trace_types.spans = v.spans;
+    Trace_types.schema_url = v.schema_url;
+  } : Trace_types.instrumentation_library_spans)
+
+let rec decode_resource_spans d =
+  let v = default_resource_spans_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.instrumentation_library_spans <- List.rev v.instrumentation_library_spans;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.resource <- Some (Resource_pb.decode_resource (Pbrt.Decoder.nested d));
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(resource_spans), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.instrumentation_library_spans <- (decode_instrumentation_library_spans (Pbrt.Decoder.nested d)) :: v.instrumentation_library_spans;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(resource_spans), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.schema_url <- Pbrt.Decoder.string d;
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(resource_spans), field(3)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Trace_types.resource = v.resource;
+    Trace_types.instrumentation_library_spans = v.instrumentation_library_spans;
+    Trace_types.schema_url = v.schema_url;
+  } : Trace_types.resource_spans)
+
+let rec decode_traces_data d =
+  let v = default_traces_data_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.resource_spans <- List.rev v.resource_spans;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.resource_spans <- (decode_resource_spans (Pbrt.Decoder.nested d)) :: v.resource_spans;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(traces_data), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Trace_types.resource_spans = v.resource_spans;
+  } : Trace_types.traces_data)
+
+let rec encode_span_span_kind (v:Trace_types.span_span_kind) encoder =
+  match v with
+  | Trace_types.Span_kind_unspecified -> Pbrt.Encoder.int_as_varint (0) encoder
+  | Trace_types.Span_kind_internal -> Pbrt.Encoder.int_as_varint 1 encoder
+  | Trace_types.Span_kind_server -> Pbrt.Encoder.int_as_varint 2 encoder
+  | Trace_types.Span_kind_client -> Pbrt.Encoder.int_as_varint 3 encoder
+  | Trace_types.Span_kind_producer -> Pbrt.Encoder.int_as_varint 4 encoder
+  | Trace_types.Span_kind_consumer -> Pbrt.Encoder.int_as_varint 5 encoder
+
+let rec encode_span_event (v:Trace_types.span_event) encoder = 
+  Pbrt.Encoder.key (1, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Trace_types.time_unix_nano encoder;
+  Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Trace_types.name encoder;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (3, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_key_value x) encoder;
+  ) v.Trace_types.attributes;
+  Pbrt.Encoder.key (4, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Trace_types.dropped_attributes_count encoder;
+  ()
+
+let rec encode_span_link (v:Trace_types.span_link) encoder = 
+  Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.bytes v.Trace_types.trace_id encoder;
+  Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.bytes v.Trace_types.span_id encoder;
+  Pbrt.Encoder.key (3, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Trace_types.trace_state encoder;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (4, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_key_value x) encoder;
+  ) v.Trace_types.attributes;
+  Pbrt.Encoder.key (5, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Trace_types.dropped_attributes_count encoder;
+  ()
+
+let rec encode_status_status_code (v:Trace_types.status_status_code) encoder =
+  match v with
+  | Trace_types.Status_code_unset -> Pbrt.Encoder.int_as_varint (0) encoder
+  | Trace_types.Status_code_ok -> Pbrt.Encoder.int_as_varint 1 encoder
+  | Trace_types.Status_code_error -> Pbrt.Encoder.int_as_varint 2 encoder
+
+let rec encode_status (v:Trace_types.status) encoder = 
+  Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Trace_types.message encoder;
+  Pbrt.Encoder.key (3, Pbrt.Varint) encoder; 
+  encode_status_status_code v.Trace_types.code encoder;
+  ()
+
+let rec encode_span (v:Trace_types.span) encoder = 
+  Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.bytes v.Trace_types.trace_id encoder;
+  Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.bytes v.Trace_types.span_id encoder;
+  Pbrt.Encoder.key (3, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Trace_types.trace_state encoder;
+  Pbrt.Encoder.key (4, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.bytes v.Trace_types.parent_span_id encoder;
+  Pbrt.Encoder.key (5, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Trace_types.name encoder;
+  Pbrt.Encoder.key (6, Pbrt.Varint) encoder; 
+  encode_span_span_kind v.Trace_types.kind encoder;
+  Pbrt.Encoder.key (7, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Trace_types.start_time_unix_nano encoder;
+  Pbrt.Encoder.key (8, Pbrt.Bits64) encoder; 
+  Pbrt.Encoder.int64_as_bits64 v.Trace_types.end_time_unix_nano encoder;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (9, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_key_value x) encoder;
+  ) v.Trace_types.attributes;
+  Pbrt.Encoder.key (10, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Trace_types.dropped_attributes_count encoder;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (11, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_span_event x) encoder;
+  ) v.Trace_types.events;
+  Pbrt.Encoder.key (12, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Trace_types.dropped_events_count encoder;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (13, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_span_link x) encoder;
+  ) v.Trace_types.links;
+  Pbrt.Encoder.key (14, Pbrt.Varint) encoder; 
+  Pbrt.Encoder.int32_as_varint v.Trace_types.dropped_links_count encoder;
+  begin match v.Trace_types.status with
+  | Some x -> 
+    Pbrt.Encoder.key (15, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_status x) encoder;
+  | None -> ();
+  end;
+  ()
+
+let rec encode_instrumentation_library_spans (v:Trace_types.instrumentation_library_spans) encoder = 
+  begin match v.Trace_types.instrumentation_library with
+  | Some x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Common_pb.encode_instrumentation_library x) encoder;
+  | None -> ();
+  end;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_span x) encoder;
+  ) v.Trace_types.spans;
+  Pbrt.Encoder.key (3, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Trace_types.schema_url encoder;
+  ()
+
+let rec encode_resource_spans (v:Trace_types.resource_spans) encoder = 
+  begin match v.Trace_types.resource with
+  | Some x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Resource_pb.encode_resource x) encoder;
+  | None -> ();
+  end;
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (2, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_instrumentation_library_spans x) encoder;
+  ) v.Trace_types.instrumentation_library_spans;
+  Pbrt.Encoder.key (3, Pbrt.Bytes) encoder; 
+  Pbrt.Encoder.string v.Trace_types.schema_url encoder;
+  ()
+
+let rec encode_traces_data (v:Trace_types.traces_data) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (encode_resource_spans x) encoder;
+  ) v.Trace_types.resource_spans;
+  ()

--- a/src/trace_pb.mli
+++ b/src/trace_pb.mli
@@ -1,0 +1,61 @@
+(** trace.proto Binary Encoding *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_span_span_kind : Trace_types.span_span_kind -> Pbrt.Encoder.t -> unit
+(** [encode_span_span_kind v encoder] encodes [v] with the given [encoder] *)
+
+val encode_span_event : Trace_types.span_event -> Pbrt.Encoder.t -> unit
+(** [encode_span_event v encoder] encodes [v] with the given [encoder] *)
+
+val encode_span_link : Trace_types.span_link -> Pbrt.Encoder.t -> unit
+(** [encode_span_link v encoder] encodes [v] with the given [encoder] *)
+
+val encode_status_status_code : Trace_types.status_status_code -> Pbrt.Encoder.t -> unit
+(** [encode_status_status_code v encoder] encodes [v] with the given [encoder] *)
+
+val encode_status : Trace_types.status -> Pbrt.Encoder.t -> unit
+(** [encode_status v encoder] encodes [v] with the given [encoder] *)
+
+val encode_span : Trace_types.span -> Pbrt.Encoder.t -> unit
+(** [encode_span v encoder] encodes [v] with the given [encoder] *)
+
+val encode_instrumentation_library_spans : Trace_types.instrumentation_library_spans -> Pbrt.Encoder.t -> unit
+(** [encode_instrumentation_library_spans v encoder] encodes [v] with the given [encoder] *)
+
+val encode_resource_spans : Trace_types.resource_spans -> Pbrt.Encoder.t -> unit
+(** [encode_resource_spans v encoder] encodes [v] with the given [encoder] *)
+
+val encode_traces_data : Trace_types.traces_data -> Pbrt.Encoder.t -> unit
+(** [encode_traces_data v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_span_span_kind : Pbrt.Decoder.t -> Trace_types.span_span_kind
+(** [decode_span_span_kind decoder] decodes a [span_span_kind] value from [decoder] *)
+
+val decode_span_event : Pbrt.Decoder.t -> Trace_types.span_event
+(** [decode_span_event decoder] decodes a [span_event] value from [decoder] *)
+
+val decode_span_link : Pbrt.Decoder.t -> Trace_types.span_link
+(** [decode_span_link decoder] decodes a [span_link] value from [decoder] *)
+
+val decode_status_status_code : Pbrt.Decoder.t -> Trace_types.status_status_code
+(** [decode_status_status_code decoder] decodes a [status_status_code] value from [decoder] *)
+
+val decode_status : Pbrt.Decoder.t -> Trace_types.status
+(** [decode_status decoder] decodes a [status] value from [decoder] *)
+
+val decode_span : Pbrt.Decoder.t -> Trace_types.span
+(** [decode_span decoder] decodes a [span] value from [decoder] *)
+
+val decode_instrumentation_library_spans : Pbrt.Decoder.t -> Trace_types.instrumentation_library_spans
+(** [decode_instrumentation_library_spans decoder] decodes a [instrumentation_library_spans] value from [decoder] *)
+
+val decode_resource_spans : Pbrt.Decoder.t -> Trace_types.resource_spans
+(** [decode_resource_spans decoder] decodes a [resource_spans] value from [decoder] *)
+
+val decode_traces_data : Pbrt.Decoder.t -> Trace_types.traces_data
+(** [decode_traces_data decoder] decodes a [traces_data] value from [decoder] *)

--- a/src/trace_pp.ml
+++ b/src/trace_pp.ml
@@ -1,0 +1,84 @@
+[@@@ocaml.warning "-27-30-39"]
+
+let rec pp_span_span_kind fmt (v:Trace_types.span_span_kind) =
+  match v with
+  | Trace_types.Span_kind_unspecified -> Format.fprintf fmt "Span_kind_unspecified"
+  | Trace_types.Span_kind_internal -> Format.fprintf fmt "Span_kind_internal"
+  | Trace_types.Span_kind_server -> Format.fprintf fmt "Span_kind_server"
+  | Trace_types.Span_kind_client -> Format.fprintf fmt "Span_kind_client"
+  | Trace_types.Span_kind_producer -> Format.fprintf fmt "Span_kind_producer"
+  | Trace_types.Span_kind_consumer -> Format.fprintf fmt "Span_kind_consumer"
+
+let rec pp_span_event fmt (v:Trace_types.span_event) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Trace_types.time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "name" Pbrt.Pp.pp_string fmt v.Trace_types.name;
+    Pbrt.Pp.pp_record_field ~first:false "attributes" (Pbrt.Pp.pp_list Common_pp.pp_key_value) fmt v.Trace_types.attributes;
+    Pbrt.Pp.pp_record_field ~first:false "dropped_attributes_count" Pbrt.Pp.pp_int32 fmt v.Trace_types.dropped_attributes_count;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_span_link fmt (v:Trace_types.span_link) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "trace_id" Pbrt.Pp.pp_bytes fmt v.Trace_types.trace_id;
+    Pbrt.Pp.pp_record_field ~first:false "span_id" Pbrt.Pp.pp_bytes fmt v.Trace_types.span_id;
+    Pbrt.Pp.pp_record_field ~first:false "trace_state" Pbrt.Pp.pp_string fmt v.Trace_types.trace_state;
+    Pbrt.Pp.pp_record_field ~first:false "attributes" (Pbrt.Pp.pp_list Common_pp.pp_key_value) fmt v.Trace_types.attributes;
+    Pbrt.Pp.pp_record_field ~first:false "dropped_attributes_count" Pbrt.Pp.pp_int32 fmt v.Trace_types.dropped_attributes_count;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_status_status_code fmt (v:Trace_types.status_status_code) =
+  match v with
+  | Trace_types.Status_code_unset -> Format.fprintf fmt "Status_code_unset"
+  | Trace_types.Status_code_ok -> Format.fprintf fmt "Status_code_ok"
+  | Trace_types.Status_code_error -> Format.fprintf fmt "Status_code_error"
+
+let rec pp_status fmt (v:Trace_types.status) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "message" Pbrt.Pp.pp_string fmt v.Trace_types.message;
+    Pbrt.Pp.pp_record_field ~first:false "code" pp_status_status_code fmt v.Trace_types.code;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_span fmt (v:Trace_types.span) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "trace_id" Pbrt.Pp.pp_bytes fmt v.Trace_types.trace_id;
+    Pbrt.Pp.pp_record_field ~first:false "span_id" Pbrt.Pp.pp_bytes fmt v.Trace_types.span_id;
+    Pbrt.Pp.pp_record_field ~first:false "trace_state" Pbrt.Pp.pp_string fmt v.Trace_types.trace_state;
+    Pbrt.Pp.pp_record_field ~first:false "parent_span_id" Pbrt.Pp.pp_bytes fmt v.Trace_types.parent_span_id;
+    Pbrt.Pp.pp_record_field ~first:false "name" Pbrt.Pp.pp_string fmt v.Trace_types.name;
+    Pbrt.Pp.pp_record_field ~first:false "kind" pp_span_span_kind fmt v.Trace_types.kind;
+    Pbrt.Pp.pp_record_field ~first:false "start_time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Trace_types.start_time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "end_time_unix_nano" Pbrt.Pp.pp_int64 fmt v.Trace_types.end_time_unix_nano;
+    Pbrt.Pp.pp_record_field ~first:false "attributes" (Pbrt.Pp.pp_list Common_pp.pp_key_value) fmt v.Trace_types.attributes;
+    Pbrt.Pp.pp_record_field ~first:false "dropped_attributes_count" Pbrt.Pp.pp_int32 fmt v.Trace_types.dropped_attributes_count;
+    Pbrt.Pp.pp_record_field ~first:false "events" (Pbrt.Pp.pp_list pp_span_event) fmt v.Trace_types.events;
+    Pbrt.Pp.pp_record_field ~first:false "dropped_events_count" Pbrt.Pp.pp_int32 fmt v.Trace_types.dropped_events_count;
+    Pbrt.Pp.pp_record_field ~first:false "links" (Pbrt.Pp.pp_list pp_span_link) fmt v.Trace_types.links;
+    Pbrt.Pp.pp_record_field ~first:false "dropped_links_count" Pbrt.Pp.pp_int32 fmt v.Trace_types.dropped_links_count;
+    Pbrt.Pp.pp_record_field ~first:false "status" (Pbrt.Pp.pp_option pp_status) fmt v.Trace_types.status;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_instrumentation_library_spans fmt (v:Trace_types.instrumentation_library_spans) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "instrumentation_library" (Pbrt.Pp.pp_option Common_pp.pp_instrumentation_library) fmt v.Trace_types.instrumentation_library;
+    Pbrt.Pp.pp_record_field ~first:false "spans" (Pbrt.Pp.pp_list pp_span) fmt v.Trace_types.spans;
+    Pbrt.Pp.pp_record_field ~first:false "schema_url" Pbrt.Pp.pp_string fmt v.Trace_types.schema_url;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_resource_spans fmt (v:Trace_types.resource_spans) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "resource" (Pbrt.Pp.pp_option Resource_pp.pp_resource) fmt v.Trace_types.resource;
+    Pbrt.Pp.pp_record_field ~first:false "instrumentation_library_spans" (Pbrt.Pp.pp_list pp_instrumentation_library_spans) fmt v.Trace_types.instrumentation_library_spans;
+    Pbrt.Pp.pp_record_field ~first:false "schema_url" Pbrt.Pp.pp_string fmt v.Trace_types.schema_url;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_traces_data fmt (v:Trace_types.traces_data) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "resource_spans" (Pbrt.Pp.pp_list pp_resource_spans) fmt v.Trace_types.resource_spans;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()

--- a/src/trace_pp.mli
+++ b/src/trace_pp.mli
@@ -1,0 +1,31 @@
+(** trace.proto Pretty Printing *)
+
+
+(** {2 Formatters} *)
+
+val pp_span_span_kind : Format.formatter -> Trace_types.span_span_kind -> unit 
+(** [pp_span_span_kind v] formats v *)
+
+val pp_span_event : Format.formatter -> Trace_types.span_event -> unit 
+(** [pp_span_event v] formats v *)
+
+val pp_span_link : Format.formatter -> Trace_types.span_link -> unit 
+(** [pp_span_link v] formats v *)
+
+val pp_status_status_code : Format.formatter -> Trace_types.status_status_code -> unit 
+(** [pp_status_status_code v] formats v *)
+
+val pp_status : Format.formatter -> Trace_types.status -> unit 
+(** [pp_status v] formats v *)
+
+val pp_span : Format.formatter -> Trace_types.span -> unit 
+(** [pp_span v] formats v *)
+
+val pp_instrumentation_library_spans : Format.formatter -> Trace_types.instrumentation_library_spans -> unit 
+(** [pp_instrumentation_library_spans v] formats v *)
+
+val pp_resource_spans : Format.formatter -> Trace_types.resource_spans -> unit 
+(** [pp_resource_spans v] formats v *)
+
+val pp_traces_data : Format.formatter -> Trace_types.traces_data -> unit 
+(** [pp_traces_data v] formats v *)

--- a/src/trace_service_pb.ml
+++ b/src/trace_service_pb.ml
@@ -1,0 +1,36 @@
+[@@@ocaml.warning "-27-30-39"]
+
+type export_trace_service_request_mutable = {
+  mutable resource_spans : Trace_types.resource_spans list;
+}
+
+let default_export_trace_service_request_mutable () : export_trace_service_request_mutable = {
+  resource_spans = [];
+}
+
+
+let rec decode_export_trace_service_request d =
+  let v = default_export_trace_service_request_mutable () in
+  let continue__= ref true in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.resource_spans <- List.rev v.resource_spans;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.resource_spans <- (Trace_pb.decode_resource_spans (Pbrt.Decoder.nested d)) :: v.resource_spans;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(export_trace_service_request), field(1)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  ({
+    Trace_service_types.resource_spans = v.resource_spans;
+  } : Trace_service_types.export_trace_service_request)
+
+let rec encode_export_trace_service_request (v:Trace_service_types.export_trace_service_request) encoder = 
+  List.iter (fun x -> 
+    Pbrt.Encoder.key (1, Pbrt.Bytes) encoder; 
+    Pbrt.Encoder.nested (Trace_pb.encode_resource_spans x) encoder;
+  ) v.Trace_service_types.resource_spans;
+  ()

--- a/src/trace_service_pb.mli
+++ b/src/trace_service_pb.mli
@@ -1,0 +1,13 @@
+(** trace_service.proto Binary Encoding *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_export_trace_service_request : Trace_service_types.export_trace_service_request -> Pbrt.Encoder.t -> unit
+(** [encode_export_trace_service_request v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_export_trace_service_request : Pbrt.Decoder.t -> Trace_service_types.export_trace_service_request
+(** [decode_export_trace_service_request decoder] decodes a [export_trace_service_request] value from [decoder] *)

--- a/src/trace_service_pp.ml
+++ b/src/trace_service_pp.ml
@@ -1,0 +1,7 @@
+[@@@ocaml.warning "-27-30-39"]
+
+let rec pp_export_trace_service_request fmt (v:Trace_service_types.export_trace_service_request) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "resource_spans" (Pbrt.Pp.pp_list Trace_pp.pp_resource_spans) fmt v.Trace_service_types.resource_spans;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()

--- a/src/trace_service_pp.mli
+++ b/src/trace_service_pp.mli
@@ -1,0 +1,7 @@
+(** trace_service.proto Pretty Printing *)
+
+
+(** {2 Formatters} *)
+
+val pp_export_trace_service_request : Format.formatter -> Trace_service_types.export_trace_service_request -> unit 
+(** [pp_export_trace_service_request v] formats v *)

--- a/src/trace_service_types.ml
+++ b/src/trace_service_types.ml
@@ -1,0 +1,12 @@
+[@@@ocaml.warning "-27-30-39"]
+
+
+type export_trace_service_request = {
+  resource_spans : Trace_types.resource_spans list;
+}
+
+let rec default_export_trace_service_request 
+  ?resource_spans:((resource_spans:Trace_types.resource_spans list) = [])
+  () : export_trace_service_request  = {
+  resource_spans;
+}

--- a/src/trace_service_types.mli
+++ b/src/trace_service_types.mli
@@ -1,0 +1,18 @@
+(** trace_service.proto Types *)
+
+
+
+(** {2 Types} *)
+
+type export_trace_service_request = {
+  resource_spans : Trace_types.resource_spans list;
+}
+
+
+(** {2 Default values} *)
+
+val default_export_trace_service_request : 
+  ?resource_spans:Trace_types.resource_spans list ->
+  unit ->
+  export_trace_service_request
+(** [default_export_trace_service_request ()] is the default value for type [export_trace_service_request] *)

--- a/src/trace_types.ml
+++ b/src/trace_types.ml
@@ -1,0 +1,167 @@
+[@@@ocaml.warning "-27-30-39"]
+
+
+type span_span_kind =
+  | Span_kind_unspecified 
+  | Span_kind_internal 
+  | Span_kind_server 
+  | Span_kind_client 
+  | Span_kind_producer 
+  | Span_kind_consumer 
+
+type span_event = {
+  time_unix_nano : int64;
+  name : string;
+  attributes : Common_types.key_value list;
+  dropped_attributes_count : int32;
+}
+
+type span_link = {
+  trace_id : bytes;
+  span_id : bytes;
+  trace_state : string;
+  attributes : Common_types.key_value list;
+  dropped_attributes_count : int32;
+}
+
+type status_status_code =
+  | Status_code_unset 
+  | Status_code_ok 
+  | Status_code_error 
+
+type status = {
+  message : string;
+  code : status_status_code;
+}
+
+type span = {
+  trace_id : bytes;
+  span_id : bytes;
+  trace_state : string;
+  parent_span_id : bytes;
+  name : string;
+  kind : span_span_kind;
+  start_time_unix_nano : int64;
+  end_time_unix_nano : int64;
+  attributes : Common_types.key_value list;
+  dropped_attributes_count : int32;
+  events : span_event list;
+  dropped_events_count : int32;
+  links : span_link list;
+  dropped_links_count : int32;
+  status : status option;
+}
+
+type instrumentation_library_spans = {
+  instrumentation_library : Common_types.instrumentation_library option;
+  spans : span list;
+  schema_url : string;
+}
+
+type resource_spans = {
+  resource : Resource_types.resource option;
+  instrumentation_library_spans : instrumentation_library_spans list;
+  schema_url : string;
+}
+
+type traces_data = {
+  resource_spans : resource_spans list;
+}
+
+let rec default_span_span_kind () = (Span_kind_unspecified:span_span_kind)
+
+let rec default_span_event 
+  ?time_unix_nano:((time_unix_nano:int64) = 0L)
+  ?name:((name:string) = "")
+  ?attributes:((attributes:Common_types.key_value list) = [])
+  ?dropped_attributes_count:((dropped_attributes_count:int32) = 0l)
+  () : span_event  = {
+  time_unix_nano;
+  name;
+  attributes;
+  dropped_attributes_count;
+}
+
+let rec default_span_link 
+  ?trace_id:((trace_id:bytes) = Bytes.create 0)
+  ?span_id:((span_id:bytes) = Bytes.create 0)
+  ?trace_state:((trace_state:string) = "")
+  ?attributes:((attributes:Common_types.key_value list) = [])
+  ?dropped_attributes_count:((dropped_attributes_count:int32) = 0l)
+  () : span_link  = {
+  trace_id;
+  span_id;
+  trace_state;
+  attributes;
+  dropped_attributes_count;
+}
+
+let rec default_status_status_code () = (Status_code_unset:status_status_code)
+
+let rec default_status 
+  ?message:((message:string) = "")
+  ?code:((code:status_status_code) = default_status_status_code ())
+  () : status  = {
+  message;
+  code;
+}
+
+let rec default_span 
+  ?trace_id:((trace_id:bytes) = Bytes.create 0)
+  ?span_id:((span_id:bytes) = Bytes.create 0)
+  ?trace_state:((trace_state:string) = "")
+  ?parent_span_id:((parent_span_id:bytes) = Bytes.create 0)
+  ?name:((name:string) = "")
+  ?kind:((kind:span_span_kind) = default_span_span_kind ())
+  ?start_time_unix_nano:((start_time_unix_nano:int64) = 0L)
+  ?end_time_unix_nano:((end_time_unix_nano:int64) = 0L)
+  ?attributes:((attributes:Common_types.key_value list) = [])
+  ?dropped_attributes_count:((dropped_attributes_count:int32) = 0l)
+  ?events:((events:span_event list) = [])
+  ?dropped_events_count:((dropped_events_count:int32) = 0l)
+  ?links:((links:span_link list) = [])
+  ?dropped_links_count:((dropped_links_count:int32) = 0l)
+  ?status:((status:status option) = None)
+  () : span  = {
+  trace_id;
+  span_id;
+  trace_state;
+  parent_span_id;
+  name;
+  kind;
+  start_time_unix_nano;
+  end_time_unix_nano;
+  attributes;
+  dropped_attributes_count;
+  events;
+  dropped_events_count;
+  links;
+  dropped_links_count;
+  status;
+}
+
+let rec default_instrumentation_library_spans 
+  ?instrumentation_library:((instrumentation_library:Common_types.instrumentation_library option) = None)
+  ?spans:((spans:span list) = [])
+  ?schema_url:((schema_url:string) = "")
+  () : instrumentation_library_spans  = {
+  instrumentation_library;
+  spans;
+  schema_url;
+}
+
+let rec default_resource_spans 
+  ?resource:((resource:Resource_types.resource option) = None)
+  ?instrumentation_library_spans:((instrumentation_library_spans:instrumentation_library_spans list) = [])
+  ?schema_url:((schema_url:string) = "")
+  () : resource_spans  = {
+  resource;
+  instrumentation_library_spans;
+  schema_url;
+}
+
+let rec default_traces_data 
+  ?resource_spans:((resource_spans:resource_spans list) = [])
+  () : traces_data  = {
+  resource_spans;
+}

--- a/src/trace_types.mli
+++ b/src/trace_types.mli
@@ -1,0 +1,149 @@
+(** trace.proto Types *)
+
+
+
+(** {2 Types} *)
+
+type span_span_kind =
+  | Span_kind_unspecified 
+  | Span_kind_internal 
+  | Span_kind_server 
+  | Span_kind_client 
+  | Span_kind_producer 
+  | Span_kind_consumer 
+
+type span_event = {
+  time_unix_nano : int64;
+  name : string;
+  attributes : Common_types.key_value list;
+  dropped_attributes_count : int32;
+}
+
+type span_link = {
+  trace_id : bytes;
+  span_id : bytes;
+  trace_state : string;
+  attributes : Common_types.key_value list;
+  dropped_attributes_count : int32;
+}
+
+type status_status_code =
+  | Status_code_unset 
+  | Status_code_ok 
+  | Status_code_error 
+
+type status = {
+  message : string;
+  code : status_status_code;
+}
+
+type span = {
+  trace_id : bytes;
+  span_id : bytes;
+  trace_state : string;
+  parent_span_id : bytes;
+  name : string;
+  kind : span_span_kind;
+  start_time_unix_nano : int64;
+  end_time_unix_nano : int64;
+  attributes : Common_types.key_value list;
+  dropped_attributes_count : int32;
+  events : span_event list;
+  dropped_events_count : int32;
+  links : span_link list;
+  dropped_links_count : int32;
+  status : status option;
+}
+
+type instrumentation_library_spans = {
+  instrumentation_library : Common_types.instrumentation_library option;
+  spans : span list;
+  schema_url : string;
+}
+
+type resource_spans = {
+  resource : Resource_types.resource option;
+  instrumentation_library_spans : instrumentation_library_spans list;
+  schema_url : string;
+}
+
+type traces_data = {
+  resource_spans : resource_spans list;
+}
+
+
+(** {2 Default values} *)
+
+val default_span_span_kind : unit -> span_span_kind
+(** [default_span_span_kind ()] is the default value for type [span_span_kind] *)
+
+val default_span_event : 
+  ?time_unix_nano:int64 ->
+  ?name:string ->
+  ?attributes:Common_types.key_value list ->
+  ?dropped_attributes_count:int32 ->
+  unit ->
+  span_event
+(** [default_span_event ()] is the default value for type [span_event] *)
+
+val default_span_link : 
+  ?trace_id:bytes ->
+  ?span_id:bytes ->
+  ?trace_state:string ->
+  ?attributes:Common_types.key_value list ->
+  ?dropped_attributes_count:int32 ->
+  unit ->
+  span_link
+(** [default_span_link ()] is the default value for type [span_link] *)
+
+val default_status_status_code : unit -> status_status_code
+(** [default_status_status_code ()] is the default value for type [status_status_code] *)
+
+val default_status : 
+  ?message:string ->
+  ?code:status_status_code ->
+  unit ->
+  status
+(** [default_status ()] is the default value for type [status] *)
+
+val default_span : 
+  ?trace_id:bytes ->
+  ?span_id:bytes ->
+  ?trace_state:string ->
+  ?parent_span_id:bytes ->
+  ?name:string ->
+  ?kind:span_span_kind ->
+  ?start_time_unix_nano:int64 ->
+  ?end_time_unix_nano:int64 ->
+  ?attributes:Common_types.key_value list ->
+  ?dropped_attributes_count:int32 ->
+  ?events:span_event list ->
+  ?dropped_events_count:int32 ->
+  ?links:span_link list ->
+  ?dropped_links_count:int32 ->
+  ?status:status option ->
+  unit ->
+  span
+(** [default_span ()] is the default value for type [span] *)
+
+val default_instrumentation_library_spans : 
+  ?instrumentation_library:Common_types.instrumentation_library option ->
+  ?spans:span list ->
+  ?schema_url:string ->
+  unit ->
+  instrumentation_library_spans
+(** [default_instrumentation_library_spans ()] is the default value for type [instrumentation_library_spans] *)
+
+val default_resource_spans : 
+  ?resource:Resource_types.resource option ->
+  ?instrumentation_library_spans:instrumentation_library_spans list ->
+  ?schema_url:string ->
+  unit ->
+  resource_spans
+(** [default_resource_spans ()] is the default value for type [resource_spans] *)
+
+val default_traces_data : 
+  ?resource_spans:resource_spans list ->
+  unit ->
+  traces_data
+(** [default_traces_data ()] is the default value for type [traces_data] *)


### PR DESCRIPTION
removes dep on ocaml-protoc, we only depend on the runtime part. 

TODO: we need to check, in CI, that lint would do nothing (just like with `dune fmt`). Not sure how to do that.