### PR TITLE
Allow spaces in header values set via `OTEL_EXPORTER_OTLP_HEADERS` 

### DIFF
--- a/src/client-cohttp-lwt/common_.ml
+++ b/src/client-cohttp-lwt/common_.ml
@@ -23,7 +23,11 @@ let get_url () = !url
 let set_url s = url := s
 
 let parse_headers s =
-  let parse_header s = Scanf.sscanf s "%s@=%s" (fun key value -> key, value) in
+  let parse_header s =
+    match String.split_on_char '=' s with
+    | [ key; value ] -> key, value
+    | _ -> failwith "Unexpected format for header"
+  in
   String.split_on_char ',' s |> List.map parse_header
 
 let default_headers = []

--- a/src/client-ocurl/common_.ml
+++ b/src/client-ocurl/common_.ml
@@ -28,7 +28,11 @@ let[@inline] with_mutex_ m f =
   Fun.protect ~finally:(fun () -> Mutex.unlock m) f
 
 let parse_headers s =
-  let parse_header s = Scanf.sscanf s "%s@=%s" (fun key value -> key, value) in
+  let parse_header s =
+    match String.split_on_char '=' s with
+    | [ key; value ] -> key, value
+    | _ -> failwith "Unexpected format for header"
+  in
   String.split_on_char ',' s |> List.map parse_header
 
 let default_headers = []


### PR DESCRIPTION
I was trying to use the library with elastic's [APM offering](https://www.elastic.co/observability/application-performance-monitoring) and I noticed errors related to authentication. Elastic's APM integration expected an authorization header of the form `Authorization=Bearer <token>`. The existing header parsing implementation in the library would discard anything after the first space and parsed this header as `(Authorization, Bearer)`. With the patch in this pull-request I was able to successfully push traces and logs to Elastic APM.

![image](https://user-images.githubusercontent.com/5814535/200097772-bb93e796-8661-4c18-aade-58298caff2ab.png)
![image](https://user-images.githubusercontent.com/5814535/200097765-f72b07d2-dd33-4095-98ad-7adeabc9308e.png)
![image](https://user-images.githubusercontent.com/5814535/200097766-e5b4d7ca-f970-4e6d-a3a3-7b9717102511.png)
