### PR TITLE
Use try%lwt over Lwt.catch

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,7 +32,8 @@
    (opentelemetry (= :version))
    (cohttp-lwt-unix :with-test)
    (odoc :with-doc)
-   (lwt (>= "5.3")))
+   (lwt (>= "5.3"))
+   lwt_ppx)
  (tags
   (instrumentation tracing opentelemetry datadog lwt)))
 
@@ -68,7 +69,7 @@
    (pbrt (>= 2.2))
    (odoc :with-doc)
    (lwt (>= "5.3"))
-   (lwt_ppx :with-test)
+   lwt_ppx
    cohttp-lwt
    cohttp-lwt-unix)
   (synopsis "Collector client for opentelemetry, using cohttp + lwt"))

--- a/opentelemetry-client-cohttp-lwt.opam
+++ b/opentelemetry-client-cohttp-lwt.opam
@@ -15,7 +15,7 @@ depends: [
   "pbrt" {>= "2.2"}
   "odoc" {with-doc}
   "lwt" {>= "5.3"}
-  "lwt_ppx" {with-test}
+  "lwt_ppx"
   "cohttp-lwt"
   "cohttp-lwt-unix"
 ]

--- a/opentelemetry-lwt.opam
+++ b/opentelemetry-lwt.opam
@@ -15,6 +15,7 @@ depends: [
   "cohttp-lwt-unix" {with-test}
   "odoc" {with-doc}
   "lwt" {>= "5.3"}
+  "lwt_ppx"
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/src/client-cohttp-lwt/common_.ml
+++ b/src/client-cohttp-lwt/common_.ml
@@ -1,4 +1,3 @@
-open Lwt.Syntax
 module Atomic = Opentelemetry_atomic.Atomic
 
 let[@inline] ( let@ ) f x = f x

--- a/src/client-cohttp-lwt/dune
+++ b/src/client-cohttp-lwt/dune
@@ -2,5 +2,6 @@
  (name opentelemetry_client_cohttp_lwt)
  (public_name opentelemetry-client-cohttp-lwt)
  (synopsis "Opentelemetry collector using cohttp+lwt+unix")
+ (preprocess (pps lwt_ppx))
  (libraries opentelemetry lwt cohttp-lwt cohttp-lwt-unix pbrt mtime
    mtime.clock.os))

--- a/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
+++ b/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
@@ -105,11 +105,11 @@ end = struct
     let body = Cohttp_lwt.Body.of_string bod in
 
     let* r =
-      Lwt.catch
-        (fun () ->
-          let+ r = Httpc.post ~headers ~body uri in
-          Ok r)
-        (fun e -> Lwt.return @@ Error e)
+      try%lwt
+        let+ r = Httpc.post ~headers ~body uri in
+        Ok r
+      with e ->
+        Lwt.return @@ Error e
     in
     match r with
     | Error e ->

--- a/src/lwt/dune
+++ b/src/lwt/dune
@@ -2,4 +2,6 @@
  (name opentelemetry_lwt)
  (public_name opentelemetry-lwt)
  (synopsis "Lwt frontend for opentelemetry")
+ (preprocess
+  (pps lwt_ppx))
  (libraries lwt opentelemetry))

--- a/src/lwt/opentelemetry_lwt.ml
+++ b/src/lwt/opentelemetry_lwt.ml
@@ -47,14 +47,13 @@ module Trace = struct
       in
       emit ?service_name [ span ]
     in
-    Lwt.catch
-      (fun () ->
-        let* x = f scope in
-        let () = finally (Ok ()) in
-        Lwt.return x)
-      (fun e ->
-        let () = finally (Error (Printexc.to_string e)) in
-        Lwt.fail e)
+    try%lwt
+      let* x = f scope in
+      let () = finally (Ok ()) in
+      Lwt.return x
+    with e ->
+      let () = finally (Error (Printexc.to_string e)) in
+      Lwt.fail e
 end
 
 module Metrics = struct


### PR DESCRIPTION
The Lwt docs [recommend](https://ocaml.org/p/lwt/5.5.0/doc/Lwt/index.html#rejection) the PPX over the function-call;

> Despite the above code, the recommended way to write Lwt.catch is using the try%lwt syntactic sugar from the [PPX](https://ocaml.org/p/lwt/5.5.0/doc/Lwt/Ppx_lwt.html).

That said, mainly a stylistic difference in this case. Feel free to just close if you're not a fan. (=