### PR TITLE
Use Lwt's sequence-associated storage instead of our own Thread_local

### DIFF
--- a/src/lwt/opentelemetry_lwt.ml
+++ b/src/lwt/opentelemetry_lwt.ml
@@ -11,13 +11,44 @@ module GC_metrics = GC_metrics
 module Metrics_callbacks = Metrics_callbacks
 module Trace_context = Trace_context
 
+module Scope = struct
+  include Scope
+
+  (**/**)
+
+  let _global_scope_key : t Lwt.key = Lwt.new_key ()
+
+  (**/**)
+
+  let get_surrounding ?scope () : t option =
+    let surrounding = Lwt.get _global_scope_key in
+    match scope, surrounding with
+    | Some _, _ -> scope
+    | None, Some _ -> surrounding
+    | None, None -> None
+
+  let[@inline] with_scope (sc : t) (f : unit -> 'a) : 'a =
+    Lwt.with_value _global_scope_key (Some sc) f
+end
+
+open struct
+  let get_surrounding_scope = Scope.get_surrounding
+end
+
 module Trace = struct
   open Proto.Trace
   include Trace
 
   (** Sync span guard *)
-  let with_ ?trace_state ?service_name ?(attrs = []) ?kind ?trace_id ?parent
-      ?scope ?links name (f : Scope.t -> 'a Lwt.t) : 'a Lwt.t =
+  let with_ ?(force_new_trace_id = false) ?trace_state ?service_name
+      ?(attrs = []) ?kind ?trace_id ?parent ?scope ?links name
+      (f : Scope.t -> 'a Lwt.t) : 'a Lwt.t =
+    let scope =
+      if force_new_trace_id then
+        None
+      else
+        get_surrounding_scope ?scope ()
+    in
     let trace_id =
       match trace_id, scope with
       | Some trace_id, _ -> trace_id
@@ -33,6 +64,8 @@ module Trace = struct
     let start_time = Timestamp_ns.now_unix_ns () in
     let span_id = Span_id.create () in
     let scope = { trace_id; span_id; events = []; attrs } in
+    (* set global scope in this thread *)
+    Scope.with_scope scope @@ fun () ->
     let finally ok =
       let status =
         match ok with

--- a/src/lwt/opentelemetry_lwt.ml
+++ b/src/lwt/opentelemetry_lwt.ml
@@ -51,12 +51,14 @@ module Trace = struct
     in
     let trace_id =
       match trace_id, scope with
+      | _ when force_new_trace_id -> Trace_id.create ()
       | Some trace_id, _ -> trace_id
       | None, Some scope -> scope.trace_id
       | None, None -> Trace_id.create ()
     in
     let parent =
       match parent, scope with
+      | _ when force_new_trace_id -> None
       | Some span_id, _ -> Some span_id
       | None, Some scope -> Some scope.span_id
       | None, None -> None

--- a/src/opentelemetry.ml
+++ b/src/opentelemetry.ml
@@ -530,14 +530,24 @@ module Scope = struct
 
   (**/**)
 
-  (** Obtain current scope from thread-local storage, if available *)
+  (** Obtain current scope from thread-local storage, if available.
+
+      {b NOTE} In an Lwt context, make sure to use
+      {!Opentelemetry_lwt.Scope.get_surrounding} instead, as thread-local
+      storage will probably not interact with suspension/resumption of green
+      threads as expected. *)
   let get_surrounding ?scope () : t option =
     match scope with
     | Some _ -> scope
     | None -> Thread_local.get _global_scope
 
   (** [with_scope sc f] calls [f()] in a context where [sc] is the
-      (thread)-local scope, then reverts to the previous local scope, if any. *)
+      (thread)-local scope, then reverts to the previous local scope, if any.
+
+      {b NOTE} In an Lwt context, make sure to use
+      {!Opentelemetry_lwt.Scope.with_scope} instead, as thread-local storage
+      will probably not interact with suspension/resumption of green threads as
+      expected. *)
   let[@inline] with_scope (sc : t) (f : unit -> 'a) : 'a =
     Thread_local.with_ _global_scope sc (fun _ -> f ())
 end
@@ -727,6 +737,11 @@ module Trace = struct
       @param force_new_trace_id if true (default false), the span will not use a
       surrounding context, or [scope], or [trace_id], but will always
       create a fresh new trace ID.
+
+      {b NOTE} In an Lwt context, make sure to use
+      {!Opentelemetry_lwt.Trace.with_} instead, as thread-local storage will
+      probably not interact with suspension/resumption of green threads as
+      expected.
 
       {b NOTE} be careful not to call this inside a Gc alarm, as it can
       cause deadlocks. *)


### PR DESCRIPTION
This stores the implicit 'global' surrounding-scope off the callstack in Lwt's "[sequence-associated storage][]" instead of our own Thread_local, as this makes more sense in the context of green threads.

I tried to match the code-style, let me know if you have any tweaks.

   [sequence-associated storage]: <https://github.com/ocsigen/lwt/blob/5.4.1/src/core/lwt.ml#L739-L775>