### PR TITLE
remove trailing slash from url

### DIFF
--- a/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
+++ b/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
@@ -93,7 +93,14 @@ end = struct
   (* send the content to the remote endpoint/path *)
   let send (_self : t) ~(config : Config.t) ~path ~decode (bod : string) :
       ('a, error) result Lwt.t =
-    let full_url = config.url ^ path in
+    let url =
+      let url = config.url in
+      if String.ends_with url ~suffix:"/" then
+        String.sub url 0 (String.length url - 1)
+      else
+        url
+    in
+    let full_url = url ^ path in
     let uri = Uri.of_string full_url in
 
     let open Cohttp in

--- a/src/client-ocurl/opentelemetry_client_ocurl.ml
+++ b/src/client-ocurl/opentelemetry_client_ocurl.ml
@@ -123,7 +123,14 @@ end = struct
     Pbrt.Encoder.reset encoder;
     encode x encoder;
     let data = Pbrt.Encoder.to_string encoder in
-    let url = config.Config.url ^ path in
+    let url =
+      let url = config.Config.url in
+      if String.ends_with url ~suffix:"/" then
+        String.sub url 0 (String.length url - 1)
+      else
+        url
+    in
+    let url = url ^ path in
     if !debug_ || config.debug then
       Printf.eprintf "opentelemetry: send http POST to %s (%dB)\n%!" url
         (String.length data);


### PR DESCRIPTION
I hit the following error while testing the `ocurl` client

```ocaml
opentelemetry: send http POST to http://localhost:4318//v1/traces (216B)
error while sending:
  code=405
  (could not decode status)
raw bytes: 343035206d6574686f64206e6f7420616c6c6f7765642c20737570706f727465643a205b504f53545d
```

Until I realised the double `//` in the URL. This is because I passed `http://localhost:4318/` (with the trailing slash) as URL config.

This PR should fix it by removing the potential trailing `/` from the config.url

note: I tested the same code with`cohttp` client, and it was even worse because it "failed" silently due to a `301` redirect response (I'll open a separate issue). 