### PR TITLE
get_url returns url from config if provided

### DIFF
--- a/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
+++ b/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
@@ -553,6 +553,9 @@ end
 
 let setup_ ?(stop = Atomic.make false) ~(config : Config.t) () =
   debug_ := config.debug;
+
+  if config.url <> get_url () then set_url config.url;
+
   let module B =
     Backend
       (struct

--- a/src/client-ocurl/opentelemetry_client_ocurl.ml
+++ b/src/client-ocurl/opentelemetry_client_ocurl.ml
@@ -430,6 +430,8 @@ let setup_ ?(stop = Atomic.make false) ~(config : Config.t) () =
   let ((module B) as backend) = mk_backend ~stop ~config () in
   Opentelemetry.Collector.set_backend backend;
 
+  if config.url <> get_url () then set_url config.url;
+
   if config.ticker_thread then (
     let sleep_ms = min 5_000 (max 2 config.batch_timeout_ms) in
     ignore (setup_ticker_thread ~stop ~sleep_ms backend () : Thread.t)

--- a/tests/dune
+++ b/tests/dune
@@ -1,3 +1,6 @@
 (tests
- (names test_trace_context)
- (libraries opentelemetry))
+ (names test_trace_context test_get_url)
+ (libraries
+  opentelemetry
+  opentelemetry-client-ocurl
+  opentelemetry-client-cohttp-lwt))

--- a/tests/test_get_url.expected
+++ b/tests/test_get_url.expected
@@ -1,2 +1,2 @@
-ocurl url = http://localhost:4318
-cohttp url = http://localhost:4318
+ocurl url = http://localhost:3000
+cohttp url = http://localhost:3000

--- a/tests/test_get_url.expected
+++ b/tests/test_get_url.expected
@@ -1,0 +1,2 @@
+ocurl url = http://localhost:4318
+cohttp url = http://localhost:4318

--- a/tests/test_get_url.ml
+++ b/tests/test_get_url.ml
@@ -1,0 +1,17 @@
+let url = "http://localhost:3000"
+
+let ocurl () =
+  let config = Opentelemetry_client_ocurl.Config.make ~url () in
+  Opentelemetry_client_ocurl.with_setup ~config () @@ fun () ->
+  let url = Opentelemetry_client_ocurl.get_url () in
+  print_endline @@ Printf.sprintf "ocurl url = %s" url
+
+let cohttp () =
+  let config = Opentelemetry_client_cohttp_lwt.Config.make ~url () in
+  Opentelemetry_client_cohttp_lwt.with_setup ~config () @@ fun () ->
+  let url = Opentelemetry_client_cohttp_lwt.get_url () in
+  print_endline @@ Printf.sprintf "cohttp url = %s" url
+
+let () =
+  ocurl ();
+  cohttp ()


### PR DESCRIPTION
Specifying an `url` to the config

```ocaml
Config.make ~url:"http://localhost:3000"
```

And then calling `get_url()` returns the default URL (or `OTEL_EXPORTER_OTLP_ENDPOINT` if provided). It would make more sense to me to show the URL from the config since that's the one actually used.

* [First commit](https://github.com/imandra-ai/ocaml-opentelemetry/commit/9c8776fde4c38363c4e8c4532def5eda1718b403) add a test (not sure if it's worth a test 😅)
* [Second commit](https://github.com/imandra-ai/ocaml-opentelemetry/pull/40/commits/85fa4996f4b8e08426e73646bb58479417e0c6fc) is the actual fix