### PR TITLE
add span context, rewrite w3c trace context

### DIFF
--- a/src/core/opentelemetry.ml
+++ b/src/core/opentelemetry.ml
@@ -730,6 +730,8 @@ module Span_link : sig
     ?dropped_attributes_count:int ->
     unit ->
     t
+
+  val of_span_ctx : ?attrs:key_value list -> Span_ctx.t -> t
 end = struct
   open Proto.Trace
 
@@ -745,6 +747,10 @@ end = struct
       ~trace_id:(Trace_id.to_bytes trace_id)
       ~span_id:(Span_id.to_bytes span_id) ?trace_state ~attributes
       ?dropped_attributes_count ()
+
+  let[@inline] of_span_ctx ?attrs ctx : t =
+    make ~trace_id:(Span_ctx.trace_id ctx) ~span_id:(Span_ctx.parent_id ctx)
+      ?attrs ()
 end
 
 (** Spans.

--- a/src/core/opentelemetry.ml
+++ b/src/core/opentelemetry.ml
@@ -271,6 +271,8 @@ module Trace_id : sig
 
   val create : unit -> t
 
+  val dummy : t
+
   val pp : Format.formatter -> t -> unit
 
   val is_valid : t -> bool
@@ -290,6 +292,8 @@ end = struct
   type t = bytes
 
   let to_bytes self = self
+
+  let dummy : t = Bytes.make 16 '\x00'
 
   let create () : t =
     let b = Collector.rand_bytes_16 () in
@@ -324,6 +328,8 @@ module Span_id : sig
 
   val create : unit -> t
 
+  val dummy : t
+
   val pp : Format.formatter -> t -> unit
 
   val is_valid : t -> bool
@@ -343,6 +349,8 @@ end = struct
   type t = bytes
 
   let to_bytes self = self
+
+  let dummy : t = Bytes.make 8 '\x00'
 
   let create () : t =
     let b = Collector.rand_bytes_8 () in
@@ -373,11 +381,15 @@ end
 
 (** Span context. This bundles up a trace ID and parent ID.
 
-    https://opentelemetry.io/docs/specs/otel/trace/api/#spancontext *)
+    https://opentelemetry.io/docs/specs/otel/trace/api/#spancontext
+    @since NEXT_RELEASE *)
 module Span_ctx : sig
   type t
 
   val make : trace_id:Trace_id.t -> parent_id:Span_id.t -> unit -> t
+
+  val dummy : t
+  (** Invalid span context, to be used as a placeholder *)
 
   val is_valid : t -> bool
 
@@ -402,6 +414,9 @@ end = struct
     parent_id: Span_id.t;
     is_remote: bool;
   }
+
+  let dummy =
+    { trace_id = Trace_id.dummy; parent_id = Span_id.dummy; is_remote = false }
 
   let make ~trace_id ~parent_id () : t =
     { trace_id; parent_id; is_remote = false }

--- a/src/core/opentelemetry.ml
+++ b/src/core/opentelemetry.ml
@@ -672,6 +672,10 @@ module Scope = struct
     mutable attrs: key_value list;
   }
 
+  (** Turn the scope into a span context *)
+  let[@inline] to_span_ctx (self : t) : Span_ctx.t =
+    Span_ctx.make ~trace_id:self.trace_id ~parent_id:self.span_id ()
+
   (** Add an event to the scope. It will be aggregated into the span.
 
       Note that this takes a function that produces an event, and will only

--- a/tests/core/test_trace_context.expected
+++ b/tests/core/test_trace_context.expected
@@ -20,6 +20,12 @@ Trace_context.Traceparent.of_value "00-0123456789abcdef0123456789abcdef-01234567
   Ok trace_id:"0123456789abcdef0123456789abcdef" parent_id:"0123456789abcdef"
 Trace_context.Traceparent.of_value "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01":
   Ok trace_id:"4bf92f3577b34da6a3ce929d0e0e4736" parent_id:"00f067aa0ba902b7"
+Trace_context.Traceparent.of_value "03-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01":
+  Error "version is 3, expected 0"
+Trace_context.Traceparent.of_value "00-ohnonohex7b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01":
+  Error "in trace id: invalid hex char: 'o'"
+Trace_context.Traceparent.of_value "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aazzzzzzb7-01":
+  Error "in span id: invalid hex char: 'z'"
 
 Trace_context.Traceparent.to_value trace_id:"4bf92f3577b34da6a3ce929d0e0e4736" parent_id:"00f067aa0ba902b7":
   "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"

--- a/tests/core/test_trace_context.expected
+++ b/tests/core/test_trace_context.expected
@@ -1,21 +1,21 @@
 Trace_context.Traceparent.of_value "xx":
-  Error "Expected version 00"
+  Error "trace context must be 55 bytes"
 Trace_context.Traceparent.of_value "00":
-  Error "Expected delimiter"
+  Error "trace context must be 55 bytes"
 Trace_context.Traceparent.of_value "00-xxxx":
-  Error "Expected 32-digit trace-id"
+  Error "trace context must be 55 bytes"
 Trace_context.Traceparent.of_value "00-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx":
-  Error "Expected hex-encoded trace-id"
+  Error "trace context must be 55 bytes"
 Trace_context.Traceparent.of_value "00-0123456789abcdef0123456789abcdef":
-  Error "Expected delimiter"
+  Error "trace context must be 55 bytes"
 Trace_context.Traceparent.of_value "00-0123456789abcdef0123456789abcdef-xxxx":
-  Error "Expected 16-digit parent-id"
+  Error "trace context must be 55 bytes"
 Trace_context.Traceparent.of_value "00-0123456789abcdef0123456789abcdef-xxxxxxxxxxxxxxxx":
-  Error "Expected hex-encoded parent-id"
+  Error "trace context must be 55 bytes"
 Trace_context.Traceparent.of_value "00-0123456789abcdef0123456789abcdef-0123456789abcdef":
-  Error "Expected delimiter"
+  Error "trace context must be 55 bytes"
 Trace_context.Traceparent.of_value "00-0123456789abcdef0123456789abcdef-0123456789abcdef-":
-  Error "Expected 2-digit flags"
+  Error "trace context must be 55 bytes"
 Trace_context.Traceparent.of_value "00-0123456789abcdef0123456789abcdef-0123456789abcdef-00":
   Ok trace_id:"0123456789abcdef0123456789abcdef" parent_id:"0123456789abcdef"
 Trace_context.Traceparent.of_value "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01":

--- a/tests/core/test_trace_context.ml
+++ b/tests/core/test_trace_context.ml
@@ -36,6 +36,12 @@ let () = test_of_value "00-0123456789abcdef0123456789abcdef-0123456789abcdef-00"
 
 let () = test_of_value "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
 
+let () = test_of_value "03-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+let () = test_of_value "00-ohnonohex7b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+let () = test_of_value "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aazzzzzzb7-01"
+
 let () = print_endline ""
 
 let test_to_value trace_id parent_id =


### PR DESCRIPTION
- feat: add Span_context, as required by OTEL API guidelines
- perf: rewrite parsing+printing for span ctx as w3c trace ctx
- test: update test output
