### PR TITLE
update a bit opentelemetry.trace

### DIFF
--- a/src/trace/opentelemetry_trace.mli
+++ b/src/trace/opentelemetry_trace.mli
@@ -36,6 +36,9 @@ module TLS := Ambient_context_tls.TLS
       ]}
     *)
 
+val on_internal_error : (string -> unit) ref
+(** Callback to print errors in the library itself (ie bugs) *)
+
 val setup : unit -> unit
 (** Install the OTEL backend as a Trace collector *)
 
@@ -156,17 +159,13 @@ module Internal : sig
   end
 
   type span_begin = {
-    id: Otel.Span_id.t;
     start_time: int64;
     name: string;
-    data: (string * Otrace.user_data) list;
     __FILE__: string;
     __LINE__: int;
     __FUNCTION__: string option;
-    trace_id: Otel.Trace_id.t;
     scope: Otel.Scope.t;
-    parent_id: Otel.Span_id.t option;
-    parent_scope: Otel.Scope.t option;
+    parent: Otel.Span_ctx.t option;
   }
 
   module Active_span_tbl : Hashtbl.S with type key = Otrace.span

--- a/src/trace/opentelemetry_trace.mli
+++ b/src/trace/opentelemetry_trace.mli
@@ -66,6 +66,8 @@ module Well_known : sig
     Otel.Span.kind * Otel.Span.key_value list
 end
 
+(**/**)
+
 (** Internal implementation details; do not consider these stable. *)
 module Internal : sig
   module M : sig
@@ -195,3 +197,5 @@ module Internal : sig
 
   val exit_span' : Otrace.span -> span_begin -> Otel.Span.t
 end
+
+(**/**)


### PR DESCRIPTION
make otel-trace a bit more lightweight by avoiding redundant fields

