### PR TITLE
Add events to spans created in trace frontend

### DIFF
--- a/src/trace/opentelemetry_trace.ml
+++ b/src/trace/opentelemetry_trace.ml
@@ -162,7 +162,7 @@ module Internal = struct
 
     let parent_id = Option.map Otel.Span_ctx.parent_id parent in
     Span.create ~kind ~trace_id:scope.trace_id ?parent:parent_id
-      ~id:scope.span_id ~start_time ~end_time ~attrs name
+      ~id:scope.span_id ~start_time ~end_time ~attrs ~events:scope.events name
     |> fst
 
   let exit_span' otrace_id otel_span_begin =


### PR DESCRIPTION
Hello, we wanted to use the tracing frontend, with the option to add otel events to the otel spans. It turns out that when spans are created in the otel tracing backend, events aren't passed through from the scope. This fixes that.