### PR TITLE
remove leftover ambient-context dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -58,7 +58,6 @@
  (depends
   (ocaml
    (>= "4.08"))
-  ambient-context
   (opentelemetry
    (= :version))
   (cohttp-lwt-unix :with-test)

--- a/opentelemetry-lwt.opam
+++ b/opentelemetry-lwt.opam
@@ -15,7 +15,6 @@ bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08"}
-  "ambient-context"
   "opentelemetry" {= version}
   "cohttp-lwt-unix" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
I think this is a leftover from https://github.com/imandra-ai/ocaml-opentelemetry/pull/59