### PR TITLE
in backends, call tick() before cleaning up

### DIFF
--- a/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
+++ b/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
@@ -567,7 +567,6 @@ let create_backend ?(stop = Atomic.make false) ?(config = Config.make ()) () =
 
 let setup_ ?stop ?config () =
   let backend = create_backend ?stop ?config () in
-  let (module B : OT.Collector.BACKEND) = backend in
   OT.Collector.set_backend backend;
   OT.Collector.remove_backend
 

--- a/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
+++ b/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
@@ -569,7 +569,11 @@ let setup_ ?stop ?config () =
   let backend = create_backend ?stop ?config () in
   let (module B : OT.Collector.BACKEND) = backend in
   OT.Collector.set_backend backend;
-  B.cleanup
+  let cleanup () =
+    B.tick ();
+    B.cleanup ()
+  in
+  cleanup
 
 let setup ?stop ?config ?(enable = true) () =
   if enable then (

--- a/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
+++ b/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
@@ -569,11 +569,7 @@ let setup_ ?stop ?config () =
   let backend = create_backend ?stop ?config () in
   let (module B : OT.Collector.BACKEND) = backend in
   OT.Collector.set_backend backend;
-  let cleanup () =
-    B.tick ();
-    B.cleanup ()
-  in
-  cleanup
+  OT.Collector.remove_backend
 
 let setup ?stop ?config ?(enable = true) () =
   if enable then (

--- a/src/client-ocurl/opentelemetry_client_ocurl.ml
+++ b/src/client-ocurl/opentelemetry_client_ocurl.ml
@@ -498,7 +498,7 @@ let setup_ticker_thread ~stop ~sleep_ms (module B : Collector.BACKEND) () =
 
 let setup_ ?(stop = Atomic.make false) ?(config : Config.t = Config.make ()) ()
     =
-  let ((module B) as backend) = create_backend ~stop ~config () in
+  let backend = create_backend ~stop ~config () in
   Opentelemetry.Collector.set_backend backend;
 
   Atomic.set Self_trace.enabled config.self_trace;

--- a/src/client-ocurl/opentelemetry_client_ocurl.ml
+++ b/src/client-ocurl/opentelemetry_client_ocurl.ml
@@ -508,12 +508,7 @@ let setup_ ?(stop = Atomic.make false) ?(config : Config.t = Config.make ()) ()
     let sleep_ms = min 60_000 (max 2 config.ticker_interval_ms) in
     ignore (setup_ticker_thread ~stop ~sleep_ms backend () : Thread.t)
   );
-
-  let cleanup () =
-    B.tick ();
-    B.cleanup ()
-  in
-  cleanup
+  OT.Collector.remove_backend
 
 let setup ?stop ?config ?(enable = true) () =
   if enable then (

--- a/src/client-ocurl/opentelemetry_client_ocurl.ml
+++ b/src/client-ocurl/opentelemetry_client_ocurl.ml
@@ -509,7 +509,11 @@ let setup_ ?(stop = Atomic.make false) ?(config : Config.t = Config.make ()) ()
     ignore (setup_ticker_thread ~stop ~sleep_ms backend () : Thread.t)
   );
 
-  B.cleanup
+  let cleanup () =
+    B.tick ();
+    B.cleanup ()
+  in
+  cleanup
 
 let setup ?stop ?config ?(enable = true) () =
   if enable then (


### PR DESCRIPTION
this helps flushing signals that are being batched.

close #69
