### PR TITLE
fix: wait for cleanup in cohttp client

### DIFF
--- a/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.mli
+++ b/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.mli
@@ -13,10 +13,13 @@ val set_headers : (string * string) list -> unit
 module Config = Config
 
 val create_backend :
+  ?after_cleanup:unit Lwt.u ->
   ?stop:bool Atomic.t ->
   ?config:Config.t ->
   unit ->
   (module Opentelemetry.Collector.BACKEND)
+(** Create a new backend using lwt and cohttp
+  @param after_cleanup if provided, this is resolved into [()] after cleanup is done (since NEXT_RELEASE)  *)
 
 val setup :
   ?stop:bool Atomic.t -> ?config:Config.t -> ?enable:bool -> unit -> unit
@@ -34,8 +37,8 @@ val with_setup :
   ?config:Config.t ->
   ?enable:bool ->
   unit ->
-  (unit -> 'a) ->
-  'a
+  (unit -> 'a Lwt.t) ->
+  'a Lwt.t
 (** [with_setup () f] is like [setup(); f()] but takes care of cleaning up
     after [f()] returns
     See {!setup} for more details. *)

--- a/tests/bin/cohttp_client.ml
+++ b/tests/bin/cohttp_client.ml
@@ -70,5 +70,4 @@ let () =
     "Check HTTP requests at \
      https://requestbin.com/r/enec1hql02hz/26qShWryt5vJc1JfrOwalhr5vQt@.";
 
-  Opentelemetry_client_cohttp_lwt.with_setup ~config () (fun () ->
-      Lwt_main.run (run ()))
+  Opentelemetry_client_cohttp_lwt.with_setup ~config () run |> Lwt_main.run

--- a/tests/bin/emit1_cohttp.ml
+++ b/tests/bin/emit1_cohttp.ml
@@ -139,5 +139,5 @@ let () =
         Printf.printf "\ndone. %d spans in %.4fs (%.4f/s)\n%!"
           (Atomic.get num_tr) elapsed n_per_sec)
   in
-  Opentelemetry_client_cohttp_lwt.with_setup ~stop ~config () @@ fun () ->
-  Lwt_main.run @@ run ()
+  Opentelemetry_client_cohttp_lwt.with_setup ~stop ~config () run
+  |> Lwt_main.run


### PR DESCRIPTION
in `Opentelemetry_client_cohttp_lwt.with_setup` we should now wait for
the cleanup to be done, by sneaking in a `unit Lwt.u` that is only
resolved after the cleanup is done.

close #41
