### PR TITLE
add cohttp upper bound version constraint

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -101,7 +101,9 @@
   (lwt
    (>= "5.3"))
   (cohttp-lwt
-   (>= "4.0.0"))
+   (and
+    (>= "4.0.0")
+    (< "6")))
   (alcotest :with-test))
  (synopsis "Opentelemetry tracing for Cohttp HTTP servers"))
 

--- a/opentelemetry-cohttp-lwt.opam
+++ b/opentelemetry-cohttp-lwt.opam
@@ -18,7 +18,7 @@ depends: [
   "opentelemetry-lwt" {= version}
   "odoc" {with-doc}
   "lwt" {>= "5.3"}
-  "cohttp-lwt" {>= "4.0.0"}
+  "cohttp-lwt" {>= "4.0.0" & < "6"}
   "alcotest" {with-test}
 ]
 build: [


### PR DESCRIPTION
I reinstalled the project into my new laptop and got the following error (+ some extra alerts)

```sh
File "src/integrations/cohttp/opentelemetry_cohttp_lwt.ml", line 231, characters 10-16:
231 |   (module Traced : Cohttp_lwt.S.Client)
                ^^^^^^
Error: Signature mismatch:
       ...
       The type `io' is required but not provided
       File "cohttp-lwt/src/s.ml", line 199, characters 11-32:
         Expected declaration
       The type `with_context' is required but not provided
       File "cohttp-lwt/src/s.ml", line 201, characters 11-48:
         Expected declaration
       The type `body' is required but not provided
       File "cohttp-lwt/src/s.ml", line 200, characters 11-29:
         Expected declaration
       The value `map_context' is required but not provided
       File "cohttp/src/client.ml", line 8, characters 2-68:
         Expected declaration
       The value `set_cache' is required but not provided
       File "cohttp-lwt/src/s.ml", line 203, characters 2-30:
         Expected declaration
```

It turns out this is because `cohttp` version 6 got installed in my switch. This PR should make sure it doesn't happen in the future