### PR TITLE
fix: opentelemetry-client-ocurl: don't block signals on Windows

### DIFF
--- a/src/client-ocurl/opentelemetry_client_ocurl.ml
+++ b/src/client-ocurl/opentelemetry_client_ocurl.ml
@@ -87,7 +87,7 @@ end
 
 (** start a thread in the background, running [f()] *)
 let start_bg_thread (f : unit -> unit) : Thread.t =
-  let run () =
+  let unix_run () =
     let signals =
       [
         Sys.sigusr1;
@@ -101,6 +101,8 @@ let start_bg_thread (f : unit -> unit) : Thread.t =
     ignore (Thread.sigmask Unix.SIG_BLOCK signals : _ list);
     f ()
   in
+  (* no signals on Windows *)
+  let run () = if Sys.win32 then f () else unix_run () in
   Thread.create run ()
 
 let str_to_hex (s : string) : string =


### PR DESCRIPTION
As of OCaml 5.3, the OCaml runtime doesn't support signals on Windows. Trying to block them with `Thread.sigmask` will raise:

    Thread 5 killed on uncaught exception Invalid_argument("Thread.sigmask not implemented")
    Raised by primitive operation at Opentelemetry_client_ocurl.start_bg_thread.run in file "src/client-ocurl/opentelemetry_client_ocurl.ml", line 106, characters 12-49