### PR TITLE
Fix a few build warnings

### DIFF
--- a/src/ambient-context/eio/opentelemetry_ambient_context_eio.ml
+++ b/src/ambient-context/eio/opentelemetry_ambient_context_eio.ml
@@ -1,4 +1,3 @@
-module TLS = Thread_local_storage
 module Fiber = Eio.Fiber
 
 open struct

--- a/src/core/opentelemetry.ml
+++ b/src/core/opentelemetry.ml
@@ -1226,9 +1226,9 @@ module Trace = struct
   }
   [@@deprecated "use Scope.t"]
 
-  let add_event = Scope.add_event [@@deprecated "use Scope.add_event"]
+  let (add_event [@deprecated "use Scope.add_event"]) = Scope.add_event
 
-  let add_attrs = Scope.add_attrs [@@deprecated "use Scope.add_attrs"]
+  let (add_attrs [@deprecated "use Scope.add_attrs"]) = Scope.add_attrs
 
   let with_' ?(force_new_trace_id = false) ?trace_state ?service_name
       ?(attrs : (string * [< value ]) list = []) ?kind ?trace_id ?parent ?scope


### PR DESCRIPTION
Fix the `unused-module` warning

```
File "src/ambient-context/eio/opentelemetry_ambient_context_eio.ml", line 1, characters 0-33:
1 | module TLS = Thread_local_storage
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning 60 [unused-module]: unused module TLS.
``` 

and the `misplaced-attribute` warning

```
Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
File "src/core/opentelemetry.ml", line 1229, characters 37-47:
1229 |   let add_event = Scope.add_event [@@deprecated "use Scope.add_event"]
                                            ^^^^^^^^^^
Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context

File "src/core/opentelemetry.ml", line 1231, characters 37-47:
1231 |   let add_attrs = Scope.add_attrs [@@deprecated "use Scope.add_attrs"]
                                            ^^^^^^^^^^
Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
```