### PR TITLE
Factor out the logic around signal encoding

### DIFF
--- a/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
+++ b/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
@@ -271,7 +271,7 @@ end
 let mk_emitter ~stop ~(config : Config.t) () : (module EMITTER) =
   let open Proto in
   let open Lwt.Syntax in
-  let module Conv = Signal.Converter () in
+  let module Conv = Signal.Converter in
   (* local helpers *)
   let open struct
     let timeout =

--- a/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
+++ b/src/client-cohttp-lwt/opentelemetry_client_cohttp_lwt.ml
@@ -377,19 +377,6 @@ let mk_emitter ~stop ~(config : Config.t) () : (module EMITTER) =
       and+ (_ : bool) = emit_metrics_maybe ~now ~force:true httpc encoder in
       ()
 
-    let tick_common_ () =
-      if Config.Env.get_debug () then
-        Printf.eprintf "tick (from %d)\n%!" (tid ());
-      sample_gc_metrics_if_needed ();
-      List.iter
-        (fun f ->
-          try f ()
-          with e ->
-            Printf.eprintf "on tick callback raised: %s\n"
-              (Printexc.to_string e))
-        (AList.get @@ Atomic.get on_tick_cbs_);
-      ()
-
     (* thread that calls [tick()] regularly, to help enforce timeouts *)
     let setup_ticker_thread ~tick ~finally () =
       let rec tick_thread () =
@@ -440,8 +427,16 @@ let mk_emitter ~stop ~(config : Config.t) () : (module EMITTER) =
     let set_on_tick_callbacks = set_on_tick_callbacks
 
     let tick_ () =
-      tick_common_ ();
+      if Config.Env.get_debug () then
+        Printf.eprintf "tick (from %d)\n%!" (tid ());
       sample_gc_metrics_if_needed ();
+      List.iter
+        (fun f ->
+          try f ()
+          with e ->
+            Printf.eprintf "on tick callback raised: %s\n"
+              (Printexc.to_string e))
+        (AList.get @@ Atomic.get on_tick_cbs_);
       let now = Mtime_clock.now () in
       let+ (_ : bool) = emit_traces_maybe ~now httpc encoder
       and+ (_ : bool) = emit_logs_maybe ~now httpc encoder

--- a/src/client-ocurl/opentelemetry_client_ocurl.ml
+++ b/src/client-ocurl/opentelemetry_client_ocurl.ml
@@ -6,6 +6,7 @@
 module OT = Opentelemetry
 module Config = Config
 module Self_trace = Opentelemetry_client.Self_trace
+module Signal = Opentelemetry_client.Signal
 open Opentelemetry
 include Common_
 
@@ -130,19 +131,9 @@ end = struct
     mutable send_threads: Thread.t array;  (** Threads that send data via http *)
   }
 
-  let send_http_ ~stop ~(config : Config.t) (client : Curl.t) encoder ~url
-      ~encode x : unit =
+  let send_http_ ~stop ~(config : Config.t) (client : Curl.t) ~url data : unit =
     let@ _sc =
       Self_trace.with_ ~kind:Span.Span_kind_producer "otel-ocurl.send-http"
-    in
-
-    let data =
-      let@ _sc =
-        Self_trace.with_ ~kind:Span.Span_kind_internal "encode-proto"
-      in
-      Pbrt.Encoder.reset encoder;
-      encode x encoder;
-      Pbrt.Encoder.to_string encoder
     in
 
     if Config.Env.get_debug () then
@@ -194,68 +185,36 @@ end = struct
       (* avoid crazy error loop *)
       Thread.delay 3.
 
-  let send_logs_http ~stop ~config (client : Curl.t) encoder
-      (l : Logs.resource_logs list list) : unit =
-    let l = List.fold_left (fun acc l -> List.rev_append l acc) [] l in
-    let@ _sp =
-      Self_trace.with_ ~kind:Span_kind_producer "send-logs"
-        ~attrs:[ "n", `Int (List.length l) ]
-    in
-
-    let x =
-      Logs_service.default_export_logs_service_request ~resource_logs:l ()
-    in
-    send_http_ ~stop ~config client encoder ~url:config.Config.common.url_logs
-      ~encode:Logs_service.encode_pb_export_logs_service_request x
-
-  let send_metrics_http ~stop ~config curl encoder
-      (l : Metrics.resource_metrics list list) : unit =
-    let l = List.fold_left (fun acc l -> List.rev_append l acc) [] l in
-    let@ _sp =
-      Self_trace.with_ ~kind:Span_kind_producer "send-metrics"
-        ~attrs:[ "n", `Int (List.length l) ]
-    in
-
-    let x =
-      Metrics_service.default_export_metrics_service_request ~resource_metrics:l
-        ()
-    in
-    send_http_ ~stop ~config curl encoder ~url:config.Config.common.url_metrics
-      ~encode:Metrics_service.encode_pb_export_metrics_service_request x
-
-  let send_traces_http ~stop ~config curl encoder
-      (l : Trace.resource_spans list list) : unit =
-    let l = List.fold_left (fun acc l -> List.rev_append l acc) [] l in
-    let@ _sp =
-      Self_trace.with_ ~kind:Span_kind_producer "send-traces"
-        ~attrs:[ "n", `Int (List.length l) ]
-    in
-
-    let x =
-      Trace_service.default_export_trace_service_request ~resource_spans:l ()
-    in
-    send_http_ ~stop ~config curl encoder ~url:config.Config.common.url_traces
-      ~encode:Trace_service.encode_pb_export_trace_service_request x
-
   let[@inline] send_event (self : t) ev : unit = B_queue.push self.q ev
 
   (** Thread that, in a loop, reads from [q] to get the next message to send via
       http *)
   let bg_thread_loop (self : t) : unit =
     Ezcurl.with_client ?set_opts:None @@ fun client ->
-    let stop = self.stop in
     let config = self.config in
-    let encoder = Pbrt.Encoder.create () in
+    let stop = self.stop in
+    let send ~name ~url ~conv signals =
+      let l = List.fold_left (fun acc l -> List.rev_append l acc) [] signals in
+      let@ _sp =
+        Self_trace.with_ ~kind:Span_kind_producer name
+          ~attrs:[ "n", `Int (List.length l) ]
+      in
+      conv l |> send_http_ ~stop ~config ~url client
+    in
+    let module Conv = Signal.Converter () in
     try
       while not (Atomic.get stop) do
         let msg = B_queue.pop self.send_q in
         match msg with
         | To_send.Send_trace tr ->
-          send_traces_http ~stop ~config client encoder tr
+          send ~name:"send-traces" ~conv:Conv.traces
+            ~url:config.common.url_traces tr
         | To_send.Send_metric ms ->
-          send_metrics_http ~stop ~config client encoder ms
+          send ~name:"send-metrics" ~conv:Conv.metrics
+            ~url:config.common.url_metrics ms
         | To_send.Send_logs logs ->
-          send_logs_http ~stop ~config client encoder logs
+          send ~name:"send-logs" ~conv:Conv.logs ~url:config.common.url_logs
+            logs
       done
     with B_queue.Closed -> ()
 

--- a/src/client-ocurl/opentelemetry_client_ocurl.ml
+++ b/src/client-ocurl/opentelemetry_client_ocurl.ml
@@ -201,7 +201,7 @@ end = struct
       in
       conv l |> send_http_ ~stop ~config ~url client
     in
-    let module Conv = Signal.Converter () in
+    let module Conv = Signal.Converter in
     try
       while not (Atomic.get stop) do
         let msg = B_queue.pop self.send_q in

--- a/src/client/client.ml
+++ b/src/client/client.ml
@@ -4,3 +4,5 @@
     and [opentelemetry-client-ocurl] packages package. *)
 
 module Config = Config
+module Signal = Signal
+module Self_trace = Self_trace

--- a/src/client/dune
+++ b/src/client/dune
@@ -1,4 +1,5 @@
 (library
  (name opentelemetry_client)
  (public_name opentelemetry.client)
+ (libraries opentelemetry pbrt)
  (synopsis "Common types and logic shared between client implementations"))

--- a/src/client/self_trace.ml
+++ b/src/client/self_trace.ml
@@ -12,7 +12,7 @@ let with_ ?kind ?attrs name f =
   if Atomic.get enabled then
     OT.Trace.with_ ?kind ?attrs name f
   else (
-    (* do nothing *)
+    (* A new scope is needed here because it might be modified *)
     let scope =
       OT.Scope.make ~trace_id:dummy_trace_id_ ~span_id:dummy_span_id ()
     in

--- a/src/client/self_trace.ml
+++ b/src/client/self_trace.ml
@@ -4,9 +4,9 @@ let enabled = Atomic.make true
 
 let add_event (scope : OT.Scope.t) ev = OT.Scope.add_event scope (fun () -> ev)
 
-let dummy_trace_id_ = OT.Trace_id.create ()
+let dummy_trace_id_ = OT.Trace_id.dummy
 
-let dummy_span_id = OT.Span_id.create ()
+let dummy_span_id = OT.Span_id.dummy
 
 let with_ ?kind ?attrs name f =
   if Atomic.get enabled then

--- a/src/client/self_trace.ml
+++ b/src/client/self_trace.ml
@@ -1,0 +1,22 @@
+module OT = Opentelemetry
+
+let enabled = Atomic.make true
+
+let add_event (scope : OT.Scope.t) ev = OT.Scope.add_event scope (fun () -> ev)
+
+let dummy_trace_id_ = OT.Trace_id.create ()
+
+let dummy_span_id = OT.Span_id.create ()
+
+let with_ ?kind ?attrs name f =
+  if Atomic.get enabled then
+    OT.Trace.with_ ?kind ?attrs name f
+  else (
+    (* do nothing *)
+    let scope =
+      OT.Scope.make ~trace_id:dummy_trace_id_ ~span_id:dummy_span_id ()
+    in
+    f scope
+  )
+
+let set_enabled b = Atomic.set enabled b

--- a/src/client/self_trace.mli
+++ b/src/client/self_trace.mli
@@ -1,0 +1,13 @@
+(** Mini tracing module (disabled if [config.self_trace=false]) *)
+
+val add_event :
+  Opentelemetry.Scope.t -> Opentelemetry_proto.Trace.span_event -> unit
+
+val with_ :
+  ?kind:Opentelemetry_proto.Trace.span_span_kind ->
+  ?attrs:(string * Opentelemetry.value) list ->
+  string ->
+  (Opentelemetry.Scope.t -> 'a) ->
+  'a
+
+val set_enabled : bool -> unit

--- a/src/client/self_trace.mli
+++ b/src/client/self_trace.mli
@@ -1,10 +1,9 @@
 (** Mini tracing module (disabled if [config.self_trace=false]) *)
 
-val add_event :
-  Opentelemetry.Scope.t -> Opentelemetry_proto.Trace.span_event -> unit
+val add_event : Opentelemetry.Scope.t -> Opentelemetry.Event.t -> unit
 
 val with_ :
-  ?kind:Opentelemetry_proto.Trace.span_span_kind ->
+  ?kind:Opentelemetry.Span_kind.t ->
   ?attrs:(string * Opentelemetry.value) list ->
   string ->
   (Opentelemetry.Scope.t -> 'a) ->

--- a/src/client/signal.ml
+++ b/src/client/signal.ml
@@ -1,0 +1,40 @@
+module Trace_service = Opentelemetry.Proto.Trace_service
+module Metrics_service = Opentelemetry.Proto.Metrics_service
+module Logs_service = Opentelemetry.Proto.Logs_service
+module Span = Opentelemetry.Span
+
+let ( let@ ) f x = f x
+
+module Converter () = struct
+  let encoder = Pbrt.Encoder.create ()
+
+  let resource_to_string ~ctor ~enc resource =
+    let x = ctor resource in
+    let@ _sc = Self_trace.with_ ~kind:Span.Span_kind_internal "encode-proto" in
+    Pbrt.Encoder.reset encoder;
+    enc x encoder;
+    Pbrt.Encoder.to_string encoder
+
+  let logs resource_logs =
+    resource_logs
+    |> resource_to_string
+         ~ctor:(fun r ->
+           Logs_service.default_export_logs_service_request ~resource_logs:r ())
+         ~enc:Logs_service.encode_pb_export_logs_service_request
+
+  let metrics resource_metrics =
+    resource_metrics
+    |> resource_to_string
+         ~ctor:(fun r ->
+           Metrics_service.default_export_metrics_service_request
+             ~resource_metrics:r ())
+         ~enc:Metrics_service.encode_pb_export_metrics_service_request
+
+  let traces resource_spans =
+    resource_spans
+    |> resource_to_string
+         ~ctor:(fun r ->
+           Trace_service.default_export_trace_service_request ~resource_spans:r
+             ())
+         ~enc:Trace_service.encode_pb_export_trace_service_request
+end

--- a/src/client/signal.ml
+++ b/src/client/signal.ml
@@ -5,34 +5,37 @@ module Span = Opentelemetry.Span
 
 let ( let@ ) = ( @@ )
 
-module Converter () = struct
-  let encoder = Pbrt.Encoder.create ()
-
-  let resource_to_string ~ctor ~enc resource =
+module Converter = struct
+  let resource_to_string ~encoder ~ctor ~enc resource =
+    let encoder =
+      match encoder with
+      | Some e -> e
+      | None -> Pbrt.Encoder.create ()
+    in
     let x = ctor resource in
     let@ _sc = Self_trace.with_ ~kind:Span.Span_kind_internal "encode-proto" in
     Pbrt.Encoder.reset encoder;
     enc x encoder;
     Pbrt.Encoder.to_string encoder
 
-  let logs resource_logs =
+  let logs ?encoder resource_logs =
     resource_logs
-    |> resource_to_string
+    |> resource_to_string ~encoder
          ~ctor:(fun r ->
            Logs_service.default_export_logs_service_request ~resource_logs:r ())
          ~enc:Logs_service.encode_pb_export_logs_service_request
 
-  let metrics resource_metrics =
+  let metrics ?encoder resource_metrics =
     resource_metrics
-    |> resource_to_string
+    |> resource_to_string ~encoder
          ~ctor:(fun r ->
            Metrics_service.default_export_metrics_service_request
              ~resource_metrics:r ())
          ~enc:Metrics_service.encode_pb_export_metrics_service_request
 
-  let traces resource_spans =
+  let traces ?encoder resource_spans =
     resource_spans
-    |> resource_to_string
+    |> resource_to_string ~encoder
          ~ctor:(fun r ->
            Trace_service.default_export_trace_service_request ~resource_spans:r
              ())

--- a/src/client/signal.ml
+++ b/src/client/signal.ml
@@ -3,7 +3,7 @@ module Metrics_service = Opentelemetry.Proto.Metrics_service
 module Logs_service = Opentelemetry.Proto.Logs_service
 module Span = Opentelemetry.Span
 
-let ( let@ ) f x = f x
+let ( let@ ) = ( @@ )
 
 module Converter () = struct
   let encoder = Pbrt.Encoder.create ()

--- a/src/client/signal.mli
+++ b/src/client/signal.mli
@@ -1,0 +1,17 @@
+(** Constructing and managing OTel
+    {{:https://opentelemetry.io/docs/concepts/signals/} signals} *)
+
+(** Convert signals to protobuf encoded strings, ready to be sent over the wire
+
+    NOTE: The converters share an underlying stateful encoder, so each domain or
+    system thread should have its own [Converter] instance *)
+module Converter : functor () -> sig
+  val logs : Opentelemetry_proto.Logs.resource_logs list -> string
+  (** [logs ls] is a protobuf encoded string of the logs [ls] *)
+
+  val metrics : Opentelemetry_proto.Metrics.resource_metrics list -> string
+  (** [metrics ms] is a protobuf encoded string of the metrics [ms] *)
+
+  val traces : Opentelemetry_proto.Trace.resource_spans list -> string
+  (** [metrics ts] is a protobuf encoded string of the traces [ts] *)
+end

--- a/src/client/signal.mli
+++ b/src/client/signal.mli
@@ -5,13 +5,27 @@
 
     NOTE: The converters share an underlying stateful encoder, so each domain or
     system thread should have its own [Converter] instance *)
-module Converter : functor () -> sig
-  val logs : Opentelemetry_proto.Logs.resource_logs list -> string
-  (** [logs ls] is a protobuf encoded string of the logs [ls] *)
+module Converter : sig
+  val logs :
+    ?encoder:Pbrt.Encoder.t ->
+    Opentelemetry_proto.Logs.resource_logs list ->
+    string
+  (** [logs ls] is a protobuf encoded string of the logs [ls]
 
-  val metrics : Opentelemetry_proto.Metrics.resource_metrics list -> string
-  (** [metrics ms] is a protobuf encoded string of the metrics [ms] *)
+      @param encoder provide an encoder state to reuse *)
 
-  val traces : Opentelemetry_proto.Trace.resource_spans list -> string
-  (** [metrics ts] is a protobuf encoded string of the traces [ts] *)
+  val metrics :
+    ?encoder:Pbrt.Encoder.t ->
+    Opentelemetry_proto.Metrics.resource_metrics list ->
+    string
+  (** [metrics ms] is a protobuf encoded string of the metrics [ms]
+      @param encoder provide an encoder state to reuse *)
+
+  val traces :
+    ?encoder:Pbrt.Encoder.t ->
+    Opentelemetry_proto.Trace.resource_spans list ->
+    string
+  (** [metrics ts] is a protobuf encoded string of the traces [ts]
+
+      @param encoder provide an encoder state to reuse *)
 end


### PR DESCRIPTION
This removes some duplication in the logic around generating protobuf messages
to send over the wire. This is preparatory for moving a lot of the logic around
prepping signals out of the individual clients.