### PR TITLE
fix: opentelemetry exception attr spec

### DIFF
--- a/src/core/opentelemetry.ml
+++ b/src/core/opentelemetry.ml
@@ -1069,9 +1069,9 @@ end = struct
         Event.make "exception"
           ~attrs:
             [
-              "message", `String (Printexc.to_string exn);
-              "type", `String (Printexc.exn_slot_name exn);
-              "stacktrace", `String (Printexc.raw_backtrace_to_string bt);
+              "exception.message", `String (Printexc.to_string exn);
+              "exception.type", `String (Printexc.exn_slot_name exn);
+              "exception.stacktrace", `String (Printexc.raw_backtrace_to_string bt);
             ]
       in
       scope.items <- Ev (ev, scope.items)


### PR DESCRIPTION
this brings the exception attributes in line with the spec https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/. It seems we were missing the preceding `exception.`