### PR TITLE
fix: make metric callbacks atomic

### DIFF
--- a/src/core/opentelemetry.ml
+++ b/src/core/opentelemetry.ml
@@ -1471,7 +1471,7 @@ module Metrics_callbacks = struct
   let register f : unit =
     (* sets [registered_with_on_tick] to [true] atomically, iff it is currently
        [false]. *)
-    if Atomic.compare_and_set registered_with_on_tick false true then
+    if not (Atomic.exchange registered_with_on_tick true) then
       (* make sure we call [f] (and others) at each tick *)
         Collector.on_tick (fun () ->
           let m = List.map (fun f -> f ()) (AList.get cbs_) |> List.flatten in


### PR DESCRIPTION
I *think* use of a non-threadsafe mutable reference for the metrics callbacks was resulting in a race condition that would sometimes produce non-deterministic results in the integration tests.

I suspect this has not affected the lwt-based collector, because of the single threaded concurrency Lwt enforces, but it began to show up in the WIP Eio rewrite, for which I am testing on cross-domain programs.

I suspect this may have also bee affecting the ocurl collector, but we don't have integration test running on that yet.

cc/ @c-cube